### PR TITLE
Add Data Protection for key storage

### DIFF
--- a/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
@@ -5,7 +5,6 @@ namespace MartinCostello.LondonTravel.Site.Middleware
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
@@ -78,7 +77,7 @@ namespace MartinCostello.LondonTravel.Site.Middleware
             _options = options;
 
             _isProduction = environment.IsProduction();
-            _environmentName = _isProduction ? null : environment.EnvironmentName;
+            _environmentName = _isProduction ? config["Azure:Environment"] : "local";
             _publicKeyPins = BuildPublicKeyPins(options.Value);
 
             _contentSecurityPolicy = BuildContentSecurityPolicy(_isProduction, false, options.Value);

--- a/src/LondonTravel.Site/Properties/launchSettings.json
+++ b/src/LondonTravel.Site/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "iisSettings": {
     "anonymousAuthentication": true,
     "windowsAuthentication": false,
@@ -14,6 +14,7 @@
       "launchUrl": "https://localhost:44310/",
       "environmentVariables": {
         "Azure:Datacenter": "Local",
+        "Azure:Environment": "Local",
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
@@ -23,6 +24,7 @@
       "launchUrl": "http://127.0.0.1:5000/",
       "environmentVariables": {
         "Azure:Datacenter": "Local",
+        "Azure:Environment": "Local",
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }

--- a/src/LondonTravel.Site/StartupBase.cs
+++ b/src/LondonTravel.Site/StartupBase.cs
@@ -15,6 +15,7 @@ namespace MartinCostello.LondonTravel.Site
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.CookiePolicy;
     using Microsoft.AspNetCore.Cors.Infrastructure;
+    using Microsoft.AspNetCore.DataProtection;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.HttpOverrides;
@@ -157,6 +158,10 @@ namespace MartinCostello.LondonTravel.Site
             services.AddApplicationInsightsTelemetry(Configuration);
             services.AddOptions();
             services.Configure<SiteOptions>(Configuration.GetSection("Site"));
+
+            services
+                .AddDataProtection()
+                .SetApplicationName($"londontravel-{(Configuration["Azure:Environment"] ?? "local").ToLowerInvariant()}");
 
             services.AddAntiforgery(
                 (p) =>

--- a/src/LondonTravel.Site/Views/Shared/_Layout.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Layout.cshtml
@@ -47,9 +47,11 @@
     @await RenderSectionAsync("scripts", required: false)
 </body>
 <!--
-    Datacenter: @Config["Azure:Datacenter"]
-    Instance:   @Environment.MachineName
-    Commit:     @GitMetadata.Commit
-    Timestamp:  @GitMetadata.Timestamp.ToString("u", CultureInfo.InvariantCulture)
+    
+    Environment: @Config["Azure:Environment"]
+    Datacenter:  @Config["Azure:Datacenter"]
+    Instance:    @Environment.MachineName
+    Commit:      @GitMetadata.Commit
+    Timestamp:   @GitMetadata.Timestamp.ToString("u", CultureInfo.InvariantCulture)
 -->
 </html>


### PR DESCRIPTION
Add Data Protection to the application services and isolate by environment.

This should resolve users being logged out between application restarts/re-deployments as the key material for sessions should be persisted.

Also adds ```Azure:Environment``` setting to the in-page footer HTML comment and HTTP response header.

Relates to #52.