### PR TITLE
Add Azure App Service logging

### DIFF
--- a/src/LondonTravel.Site/LondonTravel.Site.csproj
+++ b/src/LondonTravel.Site/LondonTravel.Site.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.CookiePolicy" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="1.0.1" />

--- a/src/LondonTravel.Site/Program.cs
+++ b/src/LondonTravel.Site/Program.cs
@@ -43,6 +43,7 @@ namespace MartinCostello.LondonTravel.Site
 
                 var builder = new WebHostBuilder()
                     .UseKestrel((p) => p.AddServerHeader = false)
+                    .UseAzureAppServices()
                     .UseAutofac()
                     .UseConfiguration(configuration)
                     .UseContentRoot(Directory.GetCurrentDirectory())

--- a/src/LondonTravel.Site/StartupBase.cs
+++ b/src/LondonTravel.Site/StartupBase.cs
@@ -81,7 +81,10 @@ namespace MartinCostello.LondonTravel.Site
             ILoggerFactory loggerFactory,
             IOptionsSnapshot<SiteOptions> options)
         {
-            loggerFactory.AddConsole(Configuration.GetSection("Logging"));
+            if (environment.IsDevelopment())
+            {
+                loggerFactory.AddConsole(Configuration.GetSection("Logging"));
+            }
 
             app.UseCustomHttpHeaders(environment, Configuration, options);
 


### PR DESCRIPTION
Now that ```WindowsAzure.Storage``` can be consumed, add in ```Microsoft.AspNetCore.AzureAppServicesIntegration```.

Also change logging to only log to the console in development.