### PR TITLE
Improve query performance

### DIFF
--- a/src/LondonTravel.Site/Identity/UserStore.cs
+++ b/src/LondonTravel.Site/Identity/UserStore.cs
@@ -162,11 +162,11 @@ namespace MartinCostello.LondonTravel.Site.Identity
                 throw new ArgumentNullException(nameof(providerKey));
             }
 
-            var results = await _client.GetAsync<LondonTravelUser>((p) => p.Logins != null, cancellationToken);
+            var results = await _client.GetAsync<LondonTravelUser>(
+                (p) => p.Logins.Contains(new LondonTravelLoginInfo() { LoginProvider = loginProvider, ProviderKey = providerKey }),
+                cancellationToken);
 
-            return results
-                .Where((p) => p.Logins.Where((r) => r.LoginProvider == loginProvider && r.ProviderKey == providerKey).Any())
-                .FirstOrDefault();
+            return results.FirstOrDefault();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fix all documents being returned to the client when querying external logins, which were then queried in-memory. This effectively meant that there was a full collection scan every time, so would get slower (and more expensive in terms of RTUs) for every user added.