### PR TITLE
Add Expect-CT response header

### DIFF
--- a/src/LondonTravel.Site/Options/CertificateTransparencyOptions.cs
+++ b/src/LondonTravel.Site/Options/CertificateTransparencyOptions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Options
+{
+    using System;
+
+    /// <summary>
+    /// A class representing the options to use for the <c>Expect-CT</c>
+    /// HTTP response header. This class cannot be inherited.
+    /// </summary>
+    public sealed class CertificateTransparencyOptions
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to enforce certificate transparency.
+        /// </summary>
+        public bool Enforce { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum period of time to cache the policy for.
+        /// </summary>
+        public TimeSpan MaxAge { get; set; }
+    }
+}

--- a/src/LondonTravel.Site/Options/ReportOptions.cs
+++ b/src/LondonTravel.Site/Options/ReportOptions.cs
@@ -21,6 +21,21 @@ namespace MartinCostello.LondonTravel.Site.Options
         public Uri ContentSecurityPolicyReportOnly { get; set; }
 
         /// <summary>
+        /// Gets or sets the URI to use for <c>Expect-CT</c>.
+        /// </summary>
+        public Uri ExpectCTEnforce { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URI to use for <c>Expect-CT</c> when not enforced.
+        /// </summary>
+        public Uri ExpectCTReportOnly { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URI to use for <c>Expect-Staple</c>.
+        /// </summary>
+        public Uri ExpectStaple { get; set; }
+
+        /// <summary>
         /// Gets or sets the URI to use for <c>Public-Key-Pins</c>.
         /// </summary>
         public Uri PublicKeyPins { get; set; }

--- a/src/LondonTravel.Site/Options/SiteOptions.cs
+++ b/src/LondonTravel.Site/Options/SiteOptions.cs
@@ -31,6 +31,11 @@ namespace MartinCostello.LondonTravel.Site.Options
         public AuthenticationOptions Authentication { get; set; }
 
         /// <summary>
+        /// Gets or sets the certificate transparency options to use.
+        /// </summary>
+        public CertificateTransparencyOptions CertificateTransparency { get; set; }
+
+        /// <summary>
         /// Gets or sets the Content Security Policy origins for the site.
         /// </summary>
         public IDictionary<string, IList<string>> ContentSecurityPolicyOrigins { get; set; }

--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -75,6 +75,10 @@
         "CollectionName": "Users_Local"
       }
     },
+    "CertificateTransparency": {
+      "Enforce": false,
+      "MaxAge": "00.00:30:00"
+    },
     "ContentSecurityPolicyOrigins": {
       "child-src": [],
       "connect-src": [

--- a/tests/LondonTravel.Site.Tests/testsettings.json
+++ b/tests/LondonTravel.Site.Tests/testsettings.json
@@ -25,6 +25,10 @@
         "CollectionName": "Users_Tests"
       }
     },
+    "CertificateTransparency": {
+      "Enforce": false,
+      "MaxAge": "00.00:30:00"
+    },
     "ContentSecurityPolicyOrigins": {},
     "ExternalLinks": {
       "Api": "/",


### PR DESCRIPTION
Add the ```Expect-CT``` HTTP response header in report-only configuration.