### PR TITLE
Actually output the Expect-CT header

### DIFF
--- a/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
@@ -116,6 +116,7 @@ namespace MartinCostello.LondonTravel.Site.Middleware
 
                     if (context.Request.IsHttps)
                     {
+                        context.Response.Headers.Add("Expect-CT", _expectCTValue);
                         context.Response.Headers.Add("Strict-Transport-Security", "max-age=31536000");
 
                         if (!string.IsNullOrWhiteSpace(_publicKeyPins))

--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -134,6 +134,9 @@
       "Reports": {
         "ContentSecurityPolicy": "https://martincostello.report-uri.io/r/default/csp/enforce",
         "ContentSecurityPolicyReportOnly": "https://martincostello.report-uri.io/r/default/csp/reportOnly",
+        "ExpectCTEnforce": "https://martincostello.report-uri.io/r/default/ct/enforce",
+        "ExpectCTReportOnly": "https://martincostello.report-uri.io/r/default/ct/reportOnly",
+        "ExpectStaple": "https://martincostello.report-uri.io/r/default/staple/reportOnly",
         "PublicKeyPins": "https://martincostello.report-uri.io/r/default/hpkp/enforce",
         "PublicKeyPinsReportOnly": "https://martincostello.report-uri.io/r/default/hpkp/reportOnly"
       }

--- a/tests/LondonTravel.Site.Tests/testsettings.json
+++ b/tests/LondonTravel.Site.Tests/testsettings.json
@@ -38,6 +38,9 @@
       "Reports": {
         "ContentSecurityPolicy": null,
         "ContentSecurityPolicyReportOnly": null,
+        "ExpectCTEnforce": null,
+        "ExpectCTReportOnly": null,
+        "ExpectStaple": null,
         "PublicKeyPins": null,
         "PublicKeyPinsReportOnly": null
       }


### PR DESCRIPTION
Last commit (for #57) missed the crucial line that actually output the ```Expect-CT``` header. Also adds missing options to set the report URIs.