### PR TITLE
Remove Serilog sink for Application Insights

### DIFF
--- a/src/LondonTravel.Site/Startup.cs
+++ b/src/LondonTravel.Site/Startup.cs
@@ -53,8 +53,7 @@ namespace MartinCostello.LondonTravel.Site
                 .Enrich.WithProperty("AzureDatacenter", configuration.AzureDatacenter())
                 .Enrich.WithProperty("AzureEnvironment", configuration.AzureEnvironment())
                 .Enrich.WithProperty("Version", GitMetadata.Commit)
-                .ReadFrom.Configuration(configuration)
-                .WriteTo.ApplicationInsightsEvents(configuration.ApplicationInsightsKey());
+                .ReadFrom.Configuration(configuration);
 
             if (environment.IsDevelopment())
             {


### PR DESCRIPTION
Remove the Serilog sink to Application Insights as it completely destroys the daily data cap, plus it didn't log structured message values anyway.