### PR TITLE
Log to Papertrail using UDP

### DIFF
--- a/src/LondonTravel.Site/Extensions/IConfigurationExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/IConfigurationExtensions.cs
@@ -57,5 +57,34 @@ namespace MartinCostello.LondonTravel.Site.Extensions
         {
             return config?["ConnectionStrings:AzureStorage"];
         }
+
+        /// <summary>
+        /// Gets the hostname to use to log to Papertrail.
+        /// </summary>
+        /// <param name="config">The <see cref="IConfiguration"/> to use.</param>
+        /// <returns>
+        /// The hostname to use to log to Papertrail, if any.
+        /// </returns>
+        public static string PapertrailHostname(this IConfiguration config)
+        {
+            return config?["Papertrail:Hostname"];
+        }
+
+        /// <summary>
+        /// Gets the UDP port to use to log to Papertrail.
+        /// </summary>
+        /// <param name="config">The <see cref="IConfiguration"/> to use.</param>
+        /// <returns>
+        /// The UDP port to use to log to Papertrail, if any.
+        /// </returns>
+        public static int PapertrailPort(this IConfiguration config)
+        {
+            if (!ushort.TryParse(config?["Papertrail:Port"], out ushort port))
+            {
+                port = 0;
+            }
+
+            return port;
+        }
     }
 }

--- a/src/LondonTravel.Site/Extensions/LoggerSinkConfigurationExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/LoggerSinkConfigurationExtensions.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Extensions
+{
+    using System.Globalization;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using Serilog;
+    using Serilog.Configuration;
+    using Serilog.Events;
+    using Serilog.Formatting;
+    using Serilog.Formatting.Display;
+
+    /// <summary>
+    /// A class containing extension methods for the <see cref="LoggerSinkConfiguration"/> class. This class cannot be inherited.
+    /// </summary>
+    public static class LoggerSinkConfigurationExtensions
+    {
+        /// <summary>
+        /// Adds a sink that writes to Papertrail.
+        /// </summary>
+        /// <param name="config">The <see cref="LoggerSinkConfiguration"/> to add the sink to.</param>
+        /// <param name="remoteAddressAsString">The remote address for the Papertrail endpoint.</param>
+        /// <param name="port">The port for the Papertrail endpoint.</param>
+        /// <returns>
+        /// The <see cref="LoggerConfiguration"/> to use for further configuration setup.
+        /// </returns>
+        public static LoggerConfiguration Papertrail(this LoggerSinkConfiguration config, string remoteAddressAsString, int port)
+        {
+            if (!IPAddress.TryParse(remoteAddressAsString, out IPAddress remoteAddress))
+            {
+                remoteAddress = Dns.GetHostAddressesAsync(remoteAddressAsString).GetAwaiter().GetResult().FirstOrDefault();
+            }
+
+            return config.Udp(remoteAddress, port, formatter: new PapertrailFormatter());
+        }
+
+        /// <summary>
+        /// A class representing a formatter for syslog messages for <c>https://papertrailapp.com</c>. This class cannot be inherited.
+        /// </summary>
+        private sealed class PapertrailFormatter : ITextFormatter
+        {
+            /// <summary>
+            /// The log facility to use. Maps to Local6.
+            /// </summary>
+            private const int Facility = 22 * 8;
+
+            /// <summary>
+            /// The message template to use.
+            /// </summary>
+            private const string OutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level}] {Message}{NewLine}{Exception}";
+
+            /// <summary>
+            /// The host name of the current machine. This field is read-only.
+            /// </summary>
+            private readonly string _hostName;
+
+            /// <summary>
+            /// The inner text format to use beyond the syslog prefix. This field is read-only.
+            /// </summary>
+            private readonly ITextFormatter _inner;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="PapertrailFormatter"/> class.
+            /// </summary>
+            internal PapertrailFormatter()
+            {
+                _hostName = Dns.GetHostName();
+                _inner = new MessageTemplateTextFormatter(OutputTemplate, CultureInfo.InvariantCulture);
+            }
+
+            /// <summary>
+            /// An enumeration of syslog logging levels.
+            /// </summary>
+            private enum SyslogLogLevel
+            {
+                Emergency = 0,
+
+                Alert,
+
+                Critical,
+
+                Error,
+
+                Warn,
+
+                Notice,
+
+                Info,
+
+                Debug,
+            }
+
+            /// <inheritdoc />
+            public void Format(LogEvent logEvent, TextWriter output)
+            {
+                SyslogLogLevel mappedLevel = MapToSyslogLevel(logEvent.Level);
+                int level = Facility + (int)mappedLevel;
+
+                // Add the syslog prefix before the rest of the UDP message is written. Note the trailing space.
+                string prefix = string.Format(CultureInfo.InvariantCulture, "<{0}>{1} ", level, _hostName);
+
+                output.Write(prefix);
+                _inner.Format(logEvent, output);
+            }
+
+            /// <summary>
+            /// Maps the specified Serilog level to a syslog level.
+            /// </summary>
+            /// <param name="level">The Serilog logging level.</param>
+            /// <returns>
+            /// The syslog logging level.
+            /// </returns>
+            private static SyslogLogLevel MapToSyslogLevel(LogEventLevel level)
+            {
+                switch (level)
+                {
+                    case LogEventLevel.Debug:
+                    case LogEventLevel.Verbose:
+                        return SyslogLogLevel.Debug;
+
+                    case LogEventLevel.Error:
+                        return SyslogLogLevel.Error;
+
+                    case LogEventLevel.Fatal:
+                        return SyslogLogLevel.Critical;
+
+                    case LogEventLevel.Warning:
+                        return SyslogLogLevel.Warn;
+
+                    case LogEventLevel.Information:
+                    default:
+                        return SyslogLogLevel.Info;
+                }
+            }
+        }
+    }
+}

--- a/src/LondonTravel.Site/LondonTravel.Site.csproj
+++ b/src/LondonTravel.Site/LondonTravel.Site.csproj
@@ -56,8 +56,8 @@
     <PackageReference Include="Serilog" Version="2.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.3.0" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.2.1" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="2.1.0" />
+    <PackageReference Include="Serilog.Sinks.UDP" Version="2.2.0" />
     <PackageReference Include="SourceLink.Create.GitHub" Version="2.0.2" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.1.1" />

--- a/src/LondonTravel.Site/Startup.cs
+++ b/src/LondonTravel.Site/Startup.cs
@@ -60,6 +60,13 @@ namespace MartinCostello.LondonTravel.Site
                 loggerConfig = loggerConfig.WriteTo.LiterateConsole();
             }
 
+            string papertrailHostname = configuration.PapertrailHostname();
+
+            if (!string.IsNullOrWhiteSpace(papertrailHostname))
+            {
+                loggerConfig.WriteTo.Papertrail(papertrailHostname, configuration.PapertrailPort());
+            }
+
             Log.Logger = loggerConfig.CreateLogger();
         }
     }

--- a/src/LondonTravel.Site/StartupBase.cs
+++ b/src/LondonTravel.Site/StartupBase.cs
@@ -87,6 +87,11 @@ namespace MartinCostello.LondonTravel.Site
             loggerFactory.AddSerilog();
             appLifetime.ApplicationStopped.Register(Log.CloseAndFlush);
 
+            if (environment.IsDevelopment())
+            {
+                loggerFactory.AddDebug();
+            }
+
             app.UseCustomHttpHeaders(environment, Configuration, options);
 
             var supportedCultures = new[]

--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -2,12 +2,13 @@
   "ConnectionStrings": {
     "AzureStorage": ""
   },
-  "Logging": {
-    "IncludeScopes": false,
-    "LogLevel": {
+  "Serilog": {
+     "MinimumLevel": {
       "Default": "Debug",
-      "Microsoft": "Information",
-      "System": "Information"
+      "Override": {
+        "System": "Warning",
+        "Microsoft": "Warning"
+      }
     }
   },
   "Site": {


### PR DESCRIPTION
  * Log to [Papertrail](https://papertrailapp.com/) using the UDP sink.
  * Fix incorrect Serilog default logging levels.
  * Add degug to ```ILoggerFactory``` in development.
  * Remove leftover reference to ```Serilog.Sinks.ApplicationInsights```.