### PR TITLE
Change the System and Microsoft log levels

### DIFF
--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -6,8 +6,8 @@
      "MinimumLevel": {
       "Default": "Debug",
       "Override": {
-        "System": "Warning",
-        "Microsoft": "Warning"
+        "System": "Error",
+        "Microsoft": "Error"
       }
     }
   },


### PR DESCRIPTION
Change the System and Microsoft log levels to Error instead of Warning as that's too noisy in Azure.

For example, for every connection:

```2017-04-01 17:26:28 [Warning] Parameter count mismatch between X-Forwarded-For and X-Forwarded-Proto.```