### PR TITLE
Restore Application Insights Serilog sink

### DIFF
--- a/src/LondonTravel.Site/LondonTravel.Site.csproj
+++ b/src/LondonTravel.Site/LondonTravel.Site.csproj
@@ -56,6 +56,7 @@
     <PackageReference Include="Serilog" Version="2.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.3.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.2.1" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.UDP" Version="2.2.0" />
     <PackageReference Include="SourceLink.Create.GitHub" Version="2.0.2" PrivateAssets="All" />

--- a/src/LondonTravel.Site/Startup.cs
+++ b/src/LondonTravel.Site/Startup.cs
@@ -53,7 +53,8 @@ namespace MartinCostello.LondonTravel.Site
                 .Enrich.WithProperty("AzureDatacenter", configuration.AzureDatacenter())
                 .Enrich.WithProperty("AzureEnvironment", configuration.AzureEnvironment())
                 .Enrich.WithProperty("Version", GitMetadata.Commit)
-                .ReadFrom.Configuration(configuration);
+                .ReadFrom.Configuration(configuration)
+                .WriteTo.ApplicationInsightsEvents(configuration.ApplicationInsightsKey());
 
             if (environment.IsDevelopment())
             {


### PR DESCRIPTION
Restore the use of the Serilog sink for Application Insights that was removed by #60.