### PR TITLE
Support DocumentDB location preferences

### DIFF
--- a/src/LondonTravel.Site/Controllers/ApiController.cs
+++ b/src/LondonTravel.Site/Controllers/ApiController.cs
@@ -58,7 +58,7 @@ namespace MartinCostello.LondonTravel.Site.Controllers
             [FromHeader(Name = "Authorization")] string authorizationHeader,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            _logger?.LogInformation("Received API request for user preferences.");
+            _logger?.LogTrace("Received API request for user preferences.");
 
             // TODO Consider allowing implicit access if the user is signed-in (i.e. access from a browser)
             if (string.IsNullOrWhiteSpace(authorizationHeader))

--- a/src/LondonTravel.Site/Controllers/ManageController.cs
+++ b/src/LondonTravel.Site/Controllers/ManageController.cs
@@ -364,9 +364,12 @@ namespace MartinCostello.LondonTravel.Site.Controllers
 
         private async Task<IdentityResult> UpdateClaimsAsync(LondonTravelUser user, ExternalLoginInfo info)
         {
+            bool commitUpdate = false;
+
             if (user.RoleClaims == null)
             {
                 user.RoleClaims = new List<LondonTravelRole>();
+                commitUpdate = true;
             }
 
             foreach (var claim in info.Principal.Claims)
@@ -381,10 +384,18 @@ namespace MartinCostello.LondonTravel.Site.Controllers
                 if (!hasClaim)
                 {
                     user.RoleClaims.Add(LondonTravelRole.FromClaim(claim));
+                    commitUpdate = true;
                 }
             }
 
-            return await _userManager.UpdateAsync(user);
+            if (commitUpdate)
+            {
+                return await _userManager.UpdateAsync(user);
+            }
+            else
+            {
+                return IdentityResult.Success;
+            }
         }
     }
 }

--- a/src/LondonTravel.Site/Identity/UserStore.cs
+++ b/src/LondonTravel.Site/Identity/UserStore.cs
@@ -43,7 +43,7 @@ namespace MartinCostello.LondonTravel.Site.Identity
         }
 
         /// <inheritdoc />
-        public async Task AddLoginAsync(LondonTravelUser user, UserLoginInfo login, CancellationToken cancellationToken)
+        public Task AddLoginAsync(LondonTravelUser user, UserLoginInfo login, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
@@ -64,12 +64,7 @@ namespace MartinCostello.LondonTravel.Site.Identity
 
             user.Logins.Add(LondonTravelLoginInfo.FromUserLoginInfo(login));
 
-            var result = await UpdateAsync(user, cancellationToken);
-
-            if (!result.Succeeded)
-            {
-                throw new InvalidOperationException($"Failed to add login for provider '{login.LoginProvider}' for user '{user.Id}'.");
-            }
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc />

--- a/src/LondonTravel.Site/Options/UserStoreOptions.cs
+++ b/src/LondonTravel.Site/Options/UserStoreOptions.cs
@@ -12,27 +12,27 @@ namespace MartinCostello.LondonTravel.Site.Options
     public sealed class UserStoreOptions
     {
         /// <summary>
-        /// Gets or sets the Azure DocumentDb service URI to use.
+        /// Gets or sets the Azure DocumentDB service URI to use.
         /// </summary>
         public Uri ServiceUri { get; set; }
 
         /// <summary>
-        /// Gets or sets the Azure DocumentDb access key to use.
+        /// Gets or sets the Azure DocumentDB access key to use.
         /// </summary>
         public string AccessKey { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the Azure DocumentDb database to use.
+        /// Gets or sets the name of the Azure DocumentDB database to use.
         /// </summary>
         public string DatabaseName { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the Azure DocumentDb collection to use.
+        /// Gets or sets the name of the Azure DocumentDB collection to use.
         /// </summary>
         public string CollectionName { get; set; }
 
         /// <summary>
-        /// Gets or sets the preferred Azure DocumentDb locations to use, if any.
+        /// Gets or sets the preferred Azure DocumentDB locations to use, if any.
         /// </summary>
         public ICollection<string> PreferredLocations { get; set; }
     }

--- a/src/LondonTravel.Site/Options/UserStoreOptions.cs
+++ b/src/LondonTravel.Site/Options/UserStoreOptions.cs
@@ -4,6 +4,7 @@
 namespace MartinCostello.LondonTravel.Site.Options
 {
     using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// A class representing the authentication user store options for the site. This class cannot be inherited.
@@ -33,6 +34,6 @@ namespace MartinCostello.LondonTravel.Site.Options
         /// <summary>
         /// Gets or sets the preferred Azure DocumentDb locations to use, if any.
         /// </summary>
-        public string[] PreferredLocations { get; set; }
+        public ICollection<string> PreferredLocations { get; set; }
     }
 }

--- a/src/LondonTravel.Site/Options/UserStoreOptions.cs
+++ b/src/LondonTravel.Site/Options/UserStoreOptions.cs
@@ -29,5 +29,10 @@ namespace MartinCostello.LondonTravel.Site.Options
         /// Gets or sets the name of the Azure DocumentDb collection to use.
         /// </summary>
         public string CollectionName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the preferred Azure DocumentDb locations to use, if any.
+        /// </summary>
+        public string[] PreferredLocations { get; set; }
     }
 }

--- a/src/LondonTravel.Site/Services/Data/DocumentClientWrapper.cs
+++ b/src/LondonTravel.Site/Services/Data/DocumentClientWrapper.cs
@@ -87,11 +87,11 @@ namespace MartinCostello.LondonTravel.Site.Services.Data
 
             await EnsureCollectionExistsAsync();
 
-            _logger?.LogInformation($"Creating document in collection '{_options.CollectionName}' of database '{_options.DatabaseName}'.");
+            _logger?.LogTrace($"Creating document in collection '{_options.CollectionName}' of database '{_options.DatabaseName}'.");
 
             var result = await _client.CreateDocumentAsync(BuildCollectionUri(), document);
 
-            _logger?.LogInformation($"Created document in collection '{_options.CollectionName}' of database '{_options.DatabaseName}'. Id: '{result.Resource.Id}'.");
+            _logger?.LogTrace($"Created document in collection '{_options.CollectionName}' of database '{_options.DatabaseName}'. Id: '{result.Resource.Id}'.");
 
             return result.Resource.Id;
         }
@@ -186,7 +186,7 @@ namespace MartinCostello.LondonTravel.Site.Services.Data
 
             await EnsureCollectionExistsAsync();
 
-            _logger?.LogInformation($"Replacing document with Id '{id}' in collection '{_options.CollectionName}' of database '{_options.DatabaseName}'.");
+            _logger?.LogTrace($"Replacing document with Id '{id}' in collection '{_options.CollectionName}' of database '{_options.DatabaseName}'.");
 
             RequestOptions options = GetOptionsForETag(etag);
 
@@ -194,7 +194,7 @@ namespace MartinCostello.LondonTravel.Site.Services.Data
             {
                 Document response = await _client.ReplaceDocumentAsync(BuildDocumentUri(id), document, options);
 
-                _logger?.LogInformation($"Replaced document with Id '{id}' in collection '{_options.CollectionName}' of database '{_options.DatabaseName}'.");
+                _logger?.LogTrace($"Replaced document with Id '{id}' in collection '{_options.CollectionName}' of database '{_options.DatabaseName}'.");
 
                 return (T)(dynamic)response;
             }

--- a/src/LondonTravel.Site/Services/Data/DocumentCollectionInitializer.cs
+++ b/src/LondonTravel.Site/Services/Data/DocumentCollectionInitializer.cs
@@ -29,7 +29,7 @@ namespace MartinCostello.LondonTravel.Site.Services.Data
         private readonly ILogger<DocumentCollectionInitializer> _logger;
 
         /// <summary>
-        /// The name of the Azure DocumentDb database. This field is read-only.
+        /// The name of the Azure DocumentDB database. This field is read-only.
         /// </summary>
         private readonly string _databaseName;
 

--- a/src/LondonTravel.Site/Services/Data/DocumentHelpers.cs
+++ b/src/LondonTravel.Site/Services/Data/DocumentHelpers.cs
@@ -8,7 +8,7 @@ namespace MartinCostello.LondonTravel.Site.Services.Data
     using Options;
 
     /// <summary>
-    /// A class containing helper methods for DocumentDb operations. This class cannot be inherited.
+    /// A class containing helper methods for DocumentDB operations. This class cannot be inherited.
     /// </summary>
     internal static class DocumentHelpers
     {
@@ -34,32 +34,32 @@ namespace MartinCostello.LondonTravel.Site.Services.Data
 
             if (options.ServiceUri == null)
             {
-                throw new ArgumentException("No DocumentDb URI is configured.", nameof(options));
+                throw new ArgumentException("No DocumentDB URI is configured.", nameof(options));
             }
 
             if (!options.ServiceUri.IsAbsoluteUri)
             {
-                throw new ArgumentException("The configured DocumentDb URI is as it is not an absolute URI.", nameof(options));
+                throw new ArgumentException("The configured DocumentDB URI is as it is not an absolute URI.", nameof(options));
             }
 
             if (string.IsNullOrEmpty(options.AccessKey))
             {
-                throw new ArgumentException("No DocumentDb access key is configured.", nameof(options));
+                throw new ArgumentException("No DocumentDB access key is configured.", nameof(options));
             }
 
             if (string.IsNullOrEmpty(options.DatabaseName))
             {
-                throw new ArgumentException("No DocumentDb database name is configured.", nameof(options));
+                throw new ArgumentException("No DocumentDB database name is configured.", nameof(options));
             }
 
             if (string.IsNullOrEmpty(options.CollectionName))
             {
-                throw new ArgumentException("No DocumentDb collection name is configured.", nameof(options));
+                throw new ArgumentException("No DocumentDB collection name is configured.", nameof(options));
             }
 
             ConnectionPolicy connectionPolicy = null;
 
-            if (options.PreferredLocations?.Length > 0)
+            if (options.PreferredLocations?.Count > 0)
             {
                 connectionPolicy = new ConnectionPolicy();
 

--- a/src/LondonTravel.Site/Services/Data/DocumentHelpers.cs
+++ b/src/LondonTravel.Site/Services/Data/DocumentHelpers.cs
@@ -57,7 +57,19 @@ namespace MartinCostello.LondonTravel.Site.Services.Data
                 throw new ArgumentException("No DocumentDb collection name is configured.", nameof(options));
             }
 
-            return new DocumentClient(options.ServiceUri, options.AccessKey);
+            ConnectionPolicy connectionPolicy = null;
+
+            if (options.PreferredLocations?.Length > 0)
+            {
+                connectionPolicy = new ConnectionPolicy();
+
+                foreach (string location in options.PreferredLocations)
+                {
+                    connectionPolicy.PreferredLocations.Add(location);
+                }
+            }
+
+            return new DocumentClient(options.ServiceUri, options.AccessKey, connectionPolicy);
         }
     }
 }

--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -73,7 +73,8 @@
         "ServiceUri": "",
         "AccessKey": "",
         "DatabaseName": "LondonTravel",
-        "CollectionName": "Users_Local"
+        "CollectionName": "Users_Local",
+        "PreferredLocations": []
       }
     },
     "CertificateTransparency": {


### PR DESCRIPTION
Support preferred DocumentDB locations when creating instances of ```DocumentClient```.

Needs testing with an actual multi-region DocumentDB database. Might also be nicer to use ```ICollection<string>``` instead of ```string[]```, provided it binds correctly with the configuration provider.