### PR TITLE
Fix inline source maps and only render GA in production

### DIFF
--- a/src/LondonTravel.Site/TagHelpers/InlineStyleTagHelper.cs
+++ b/src/LondonTravel.Site/TagHelpers/InlineStyleTagHelper.cs
@@ -112,6 +112,8 @@ namespace MartinCostello.LondonTravel.Site.TagHelpers
                     css = MinifyCss(css);
                 }
 
+                css = FixSourceMapPath(css, filePath);
+
                 Cache.Set(cacheKey, css);
             }
 
@@ -166,6 +168,49 @@ namespace MartinCostello.LondonTravel.Site.TagHelpers
             }
 
             return builder.ToString();
+        }
+
+        /// <summary>
+        /// Attempts to fix the source map path for the specified CSS.
+        /// </summary>
+        /// <param name="css">The CSS that may contain a source map path.</param>
+        /// <param name="filePath">The path of the file containing the CSS.</param>
+        /// <returns>
+        /// The CSS that may have had the source map path fixed.
+        /// </returns>
+        /// <remarks>
+        /// Rendering the CSS inline with an embedded source map path in a comment
+        /// may result in 404 errors from trying to fetch the map file with a relative
+        /// path to the document where the CSS is inlined, which is unlikely to match
+        /// the relative path from the original CSS file that the map file has.
+        /// </remarks>
+        private string FixSourceMapPath(string css, string filePath)
+        {
+            // Is there a map file?
+            string mapFilePath = $"{filePath}.map";
+            IFileInfo fileInfo = HostingEnvironment.WebRootFileProvider.GetFileInfo(mapFilePath);
+
+            if (fileInfo.Exists)
+            {
+                const string SourceMapPreamble = "sourceMappingURL=";
+
+                int startIndex = css.IndexOf(SourceMapPreamble);
+
+                if (startIndex > -1)
+                {
+                    startIndex += SourceMapPreamble.Length;
+
+                    int endIndex = css.IndexOf(" ", startIndex);
+
+                    if (endIndex > -1)
+                    {
+                        css = css.Remove(startIndex, endIndex - startIndex);
+                        css = css.Insert(startIndex, mapFilePath);
+                    }
+                }
+            }
+
+            return css;
         }
     }
 }

--- a/src/LondonTravel.Site/Views/Shared/_Meta.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Meta.cshtml
@@ -1,6 +1,10 @@
 ﻿@using Microsoft.AspNetCore.Hosting
 @model MetaModel
+@inject IConfiguration Config
 @inject IHostingEnvironment Hosting
+@{
+    bool renderGA = string.Equals(Config.AzureEnvironment(), "production", StringComparison.OrdinalIgnoreCase);
+}
     <title>@Model.Title</title>
     <meta http-equiv="cache-control" content="no-cache, no-store" />
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -48,7 +52,7 @@
     <meta name="twitter:title" content="@Model.Title" />
     <meta name="twitter:url" content="@Model.CanonicalUri" />
     <meta name="application-name" content="@Model.SiteName" />
-    <meta name="google-analytics" content="@(Hosting.IsProduction() ? Options.Analytics.Google : string.Empty)" />
+    <meta name="google-analytics" content="@(renderGA ? Options.Analytics.Google : string.Empty)" />
     <meta name="google-site-verification" content="ji6SNsPQEbNQmF252sQgQFswh-b6cDnNOa3AHvgo4J0" />
     <meta name="msapplication-config" content="@Url.Content("~/browserconfig.xml")" />
     <meta name="msapplication-navbutton-color" content="#2b5797" />


### PR DESCRIPTION
  1. Fix-up source map file paths in inline CSS.
  1. Only render GA ```meta``` tag content in Azure Production.