### PR TITLE
Cache npm and NuGet dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ branches:
   only:
     - master
 
+cache:
+  directories:
+    - node_modules
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ branches:
 
 cache:
   directories:
-    - node_modules
+    - src/LondonTravel.Site/node_modules
 
 addons:
   apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ branches:
     - master
 
 cache:
-  - node_modules
+  - src\LondonTravel.Site\node_modules
   - '%APPDATA%\npm-cache'
   - '%USERPROFILE%\.nuget\packages'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,11 @@ branches:
   only:
     - master
 
+cache:
+  - node_modules
+  - '%APPDATA%\npm-cache'
+  - '%USERPROFILE%\.nuget\packages'
+
 install:
   - ps: npm install -g npm --loglevel=error
   - ps: npm install -g gulp --loglevel=error


### PR DESCRIPTION
Cache npm modules and NuGet dependencies in AppVeyor CI builds.