### PR TITLE
More CI caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ branches:
 cache:
   directories:
     - /home/travis/.npm
+    - /home/travis/.nuget/packages
     - src/LondonTravel.Site/node_modules
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ install:
   - curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
   - export PATH="$DOTNET_INSTALL_DIR:$PATH"
   - dotnet --info
-  - npm install -g npm
-  - npm install -g gulp
-  - npm install -g typescript
+  - npm install -g npm@4.5.0
+  - npm install -g gulp@3.9.1
+  - npm install -g typescript@2.2.2
 
 script:
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ branches:
 
 cache:
   directories:
+    - /home/travis/.npm
     - src/LondonTravel.Site/node_modules
 
 addons:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ branches:
 
 cache:
   - src\LondonTravel.Site\node_modules
+  - '%APPDATA%\npm\node_modules'
   - '%APPDATA%\npm-cache'
   - '%USERPROFILE%\.nuget\packages'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,9 @@ cache:
   - '%USERPROFILE%\.nuget\packages'
 
 install:
-  - ps: npm install -g npm --loglevel=error
-  - ps: npm install -g gulp --loglevel=error
-  - ps: npm install -g typescript --loglevel=error
+  - ps: npm install -g npm@4.5.0 --loglevel=error
+  - ps: npm install -g gulp@3.9.1 --loglevel=error
+  - ps: npm install -g typescript@2.2.2 --loglevel=error
 
 build_script:
   - ps: .\Build.ps1

--- a/src/LondonTravel.Site/package.json
+++ b/src/LondonTravel.Site/package.json
@@ -32,6 +32,6 @@
     "path": "0.12.7",
     "phantomjs-prebuilt": "2.1.14",
     "tslint": "4.5.1",
-    "typescript": "2.2.1"
+    "typescript": "2.2.2"
   }
 }


### PR DESCRIPTION
  * Cache NuGet packages in Travis CI builds.
  * Cache globally installed npm packages in AppVeyor and Travis CI.
  * Pin globally installed npm packages to a specific version instead of "latest".
  * Update to Typescript 2.2.2.