### PR TITLE
Remove NuGet cache from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,6 @@ cache:
   - src\LondonTravel.Site\node_modules
   - '%APPDATA%\npm\node_modules'
   - '%APPDATA%\npm-cache'
-  - '%USERPROFILE%\.nuget\packages'
 
 install:
   - ps: npm install -g npm@4.5.0 --loglevel=error


### PR DESCRIPTION
Remove the NuGet cache from AppVeyor as it appears to make the build slower due to the time taken to un-GZip the cache.