### PR TITLE
Remove global typescript npm module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ install:
   - dotnet --info
   - npm install -g npm@4.5.0
   - npm install -g gulp@3.9.1
-  - npm install -g typescript@2.2.2
 
 script:
   - ./build.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,6 @@ cache:
 install:
   - ps: npm install -g npm@4.5.0 --loglevel=error
   - ps: npm install -g gulp@3.9.1 --loglevel=error
-  - ps: npm install -g typescript@2.2.2 --loglevel=error
 
 build_script:
   - ps: .\Build.ps1


### PR DESCRIPTION
Do not install the typescript module globally as it is handled by gulp as a local module.