### PR TITLE
Explicitly allow HTTP HEAD for anti-crawlers

### DIFF
--- a/src/LondonTravel.Site/Controllers/ErrorController.cs
+++ b/src/LondonTravel.Site/Controllers/ErrorController.cs
@@ -140,6 +140,8 @@ namespace MartinCostello.LondonTravel.Site.Controllers
         /// <returns>
         /// The result for the action.
         /// </returns>
+        [HttpGet]
+        [HttpHead]
         [Route("admin.php")]
         [Route("admin-console")]
         [Route("admin/login.php")]


### PR DESCRIPTION
Explicitly allow HTTP HEAD for the anti-crawler routes so it does not generate a 404.