### PR TITLE
Remove "unsafe-inline" from CSP

### DIFF
--- a/src/LondonTravel.Site/Controllers/ErrorController.cs
+++ b/src/LondonTravel.Site/Controllers/ErrorController.cs
@@ -152,11 +152,13 @@ namespace MartinCostello.LondonTravel.Site.Controllers
         [Route("invoker/JMXInvokerServlet")]
         [Route("jmx-console/HtmlAdaptor")]
         [Route("magmi/web/magmi.php")]
+        [Route("readme.html")]
         [Route("web-console/Invoker")]
         [Route("wp-admin/admin-ajax.php")]
         [Route("wp-admin/includes/themes.php")]
         [Route("wp-admin/options-link.php")]
         [Route("wp-admin/post-new.php")]
+        [Route("wp-links-opml.php")]
         [Route("wp-login.php")]
         [Route("xmlrpc.php")]
         public ActionResult No()

--- a/src/LondonTravel.Site/Extensions/HttpContextExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/HttpContextExtensions.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Extensions
+{
+    using System;
+    using System.Security.Cryptography;
+    using Microsoft.AspNetCore.Http;
+
+    /// <summary>
+    /// A class containing extension methods for the <see cref="HttpContext"/> class. This class cannot be inherited.
+    /// </summary>
+    public static class HttpContextExtensions
+    {
+        /// <summary>
+        /// The name of the key for storing the CSP nonce.
+        /// </summary>
+        private const string CspNonceKey = "x-csp-nonce";
+
+        /// <summary>
+        /// Gets the CSP nonce value for the current HTTP context, generating one if not already set.
+        /// </summary>
+        /// <param name="context">The HTTP context to get the CSP nonce from.</param>
+        /// <returns>
+        /// The current CSP nonce value, if any.
+        /// </returns>
+        public static string EnsureCspNonce(this HttpContext context)
+        {
+            string nonce = context.GetCspNonce();
+
+            if (nonce == null)
+            {
+                using (var random = RandomNumberGenerator.Create())
+                {
+                    byte[] data = new byte[32];
+                    random.GetBytes(data);
+
+                    nonce = Convert.ToBase64String(data).Replace("+", "/"); // '+' causes encoding issues with TagHelpers
+                }
+
+                context.SetCspNonce(nonce);
+            }
+
+            return nonce;
+        }
+
+        /// <summary>
+        /// Gets the CSP nonce value, if any, for the current HTTP context.
+        /// </summary>
+        /// <param name="context">The HTTP context to get the CSP nonce from.</param>
+        /// <returns>
+        /// The current CSP nonce value, if any.
+        /// </returns>
+        public static string GetCspNonce(this HttpContext context)
+        {
+            string nonce = null;
+
+            if (context.Items.TryGetValue(CspNonceKey, out object value))
+            {
+                nonce = value as string;
+            }
+
+            return nonce;
+        }
+
+        /// <summary>
+        /// Sets the CSP nonce value for the current HTTP context.
+        /// </summary>
+        /// <param name="context">The HTTP context to set the CSP nonce for.</param>
+        /// <param name="nonce">The value of the CSP nonce.</param>
+        public static void SetCspNonce(this HttpContext context, string nonce)
+        {
+            context.Items[CspNonceKey] = nonce;
+        }
+    }
+}

--- a/src/LondonTravel.Site/Extensions/JavaScriptSnippetExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/JavaScriptSnippetExtensions.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Extensions
+{
+    using Microsoft.ApplicationInsights.AspNetCore;
+    using Microsoft.AspNetCore.Http;
+
+    /// <summary>
+    /// A class containing extension methods for the <see cref="JavaScriptSnippet"/> class. This class cannot be inherited.
+    /// </summary>
+    public static class JavaScriptSnippetExtensions
+    {
+        /// <summary>
+        /// The string to find to insert the CSP nonce attribute.
+        /// </summary>
+        private const string OpeningScriptTag = "<script ";
+
+        /// <summary>
+        /// Gets a code snippet with instrumentation key initialized from <see cref="TelemetryConfiguration"/>.
+        /// </summary>
+        /// <param name="snippet">The <see cref="JavaScriptSnippet"/> to use.</param>
+        /// <param name="context">The current HTTP context.</param>
+        /// <returns>
+        /// JavaScript code snippet with instrumentation key or empty if instrumentation key was not set for the application.
+        /// </returns>
+        public static string FullScriptWithCspNonce(this JavaScriptSnippet snippet, HttpContext context)
+        {
+            string script = snippet.FullScript;
+
+            if (!string.IsNullOrEmpty(script))
+            {
+                int index = script.IndexOf(OpeningScriptTag);
+
+                if (index > -1)
+                {
+                    string nonce = context.EnsureCspNonce();
+                    script = script.Insert(index + OpeningScriptTag.Length, $"nonce=\"{nonce}\" ");
+                }
+            }
+
+            return script;
+        }
+    }
+}

--- a/src/LondonTravel.Site/TagHelpers/InlineStyleTagHelper.cs
+++ b/src/LondonTravel.Site/TagHelpers/InlineStyleTagHelper.cs
@@ -22,6 +22,7 @@ namespace MartinCostello.LondonTravel.Site.TagHelpers
     /// </summary>
     [HtmlTargetElement("link", Attributes = InlineAttributeName, TagStructure = TagStructure.WithoutEndTag)]
     [HtmlTargetElement("link", Attributes = MinifyInlinedAttributeName, TagStructure = TagStructure.WithoutEndTag)]
+    [HtmlTargetElement("link", Attributes = NonceAttributeName, TagStructure = TagStructure.WithoutEndTag)]
     public class InlineStyleTagHelper : LinkTagHelper
     {
         /// <summary>
@@ -33,6 +34,11 @@ namespace MartinCostello.LondonTravel.Site.TagHelpers
         /// The name of the <c>asp-inline</c> attribute.
         /// </summary>
         private const string MinifyInlinedAttributeName = "asp-minify-inlined";
+
+        /// <summary>
+        /// The name of the <c>asp-csp-nonce</c> attribute.
+        /// </summary>
+        private const string NonceAttributeName = "asp-csp-nonce";
 
         /// <summary>
         /// An array containing the <see cref="Environment.NewLine"/> string.
@@ -120,6 +126,11 @@ namespace MartinCostello.LondonTravel.Site.TagHelpers
             output.Content.SetHtmlContent(css);
 
             output.Attributes.Clear();
+
+            if (context.AllAttributes.TryGetAttribute(NonceAttributeName, out TagHelperAttribute nonceAttribute))
+            {
+                output.Attributes.Add("nonce", nonceAttribute.Value.ToString());
+            }
 
             output.TagName = "style";
             output.TagMode = TagMode.StartTagAndEndTag;

--- a/src/LondonTravel.Site/Views/Shared/_Layout.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Layout.cshtml
@@ -25,8 +25,8 @@
     @await RenderSectionAsync("meta", required: false)
     @await Html.PartialAsync("_StylesHead")
     @await RenderSectionAsync("stylesHead", required: false)
-    @Html.Raw(JavaScriptSnippet.FullScript)
-    <script type="text/javascript">
+    @Html.Raw(JavaScriptSnippet.FullScriptWithCspNonce(Context))
+    <script type="text/javascript" nonce="@Context.EnsureCspNonce()">
         if (self == top) {
             document.documentElement.className = document.documentElement.className.replace(/\bjs-flash\b/, '');
         }

--- a/src/LondonTravel.Site/Views/Shared/_StylesHead.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_StylesHead.cshtml
@@ -1,6 +1,6 @@
 ﻿<environment names="Development">
-    <link rel="stylesheet" href="~/assets/css/site.css" asp-append-version="true" asp-inline="true" asp-minify-inlined="true" />
+    <link rel="stylesheet" href="~/assets/css/site.css" asp-append-version="true" asp-csp-nonce="@Context.EnsureCspNonce()" asp-inline="true" asp-minify-inlined="true" />
 </environment>
 <environment names="Staging,Production">
-    <link rel="stylesheet" href="~/assets/css/site.min.css" asp-append-version="true" asp-inline="true" />
+    <link rel="stylesheet" href="~/assets/css/site.min.css" asp-append-version="true" asp-csp-nonce="@Context.EnsureCspNonce()" asp-inline="true" />
 </environment>

--- a/tests/LondonTravel.Site.Tests/Integration/ResourceTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/ResourceTests.cs
@@ -114,7 +114,10 @@ namespace MartinCostello.LondonTravel.Site.Integration
             string[] expectedHeaders = new[]
             {
                 "content-security-policy",
+                "content-security-policy-report-only",
+                "Referrer-Policy",
                 "X-Content-Type-Options",
+                "X-CSP-Nonce",
                 "X-Datacenter",
                 "X-Download-Options",
                 "X-Frame-Options",


### PR DESCRIPTION
  * Remove use if `unsafe-inline` from the Content Security Policy by instead using a nonce.
  * Add two additional redirect routes for crawlers.