### PR TITLE
Load jQuery from Cloudflare CDN

### DIFF
--- a/src/LondonTravel.Site/Views/Shared/_Links.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Links.cshtml
@@ -35,14 +35,14 @@
     <link rel="apple-touch-icon-precomposed" href="@Url.CdnContent("apple-touch-icon.png", options)" />
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="@Url.CdnContent("apple-touch-icon-152x152.png", options)" />
     <link rel="apple-touch-icon-precomposed" sizes="180x180" href="@Url.CdnContent("apple-touch-icon-precomposed.png", options)" />
-    <link rel="dns-prefetch" href="//ajax.googleapis.com" />
     <link rel="dns-prefetch" href="//@options?.ExternalLinks?.Cdn?.Host" />
+    <link rel="dns-prefetch" href="//cdn.cloudflare.com" />
     <link rel="dns-prefetch" href="//fonts.googleapis.com" />
     <link rel="dns-prefetch" href="//fonts.gstatic.com" />
     <link rel="dns-prefetch" href="//maxcdn.bootstrapcdn.com" />
     <link rel="dns-prefetch" href="//www.google-analytics.com" />
-    <link rel="preconnect" href="//ajax.googleapis.com" />
     <link rel="preconnect" href="//@options?.ExternalLinks?.Cdn?.Host" />
+    <link rel="preconnect" href="//cdn.cloudflare.com" />
     <link rel="preconnect" href="//fonts.googleapis.com" />
     <link rel="preconnect" href="//fonts.gstatic.com" />
     <link rel="preconnect" href="//maxcdn.bootstrapcdn.com" />

--- a/src/LondonTravel.Site/Views/Shared/_Scripts.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Scripts.cshtml
@@ -1,4 +1,4 @@
-﻿    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous" defer></script>
+﻿    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous" defer></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.min.js" integrity="sha256-rXnOfjTRp4iAm7hTAxEz3irkXzwZrElV2uRsdJAYjC4=" crossorigin="anonymous" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js" integrity="sha256-1hjUhpc44NwiNg8OwMu2QzJXhD8kcj+sJA3aCQZoUjg=" crossorigin="anonymous" defer></script>

--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -96,7 +96,6 @@
         "maxcdn.bootstrapcdn.com"
       ],
       "font-src": [
-        "ajax.googleapis.com",
         "fonts.googleapis.com",
         "fonts.gstatic.com",
         "maxcdn.bootstrapcdn.com"
@@ -122,14 +121,12 @@
       ],
       "object-src": [],
       "script-src": [
-        "ajax.googleapis.com",
         "az416426.vo.msecnd.net",
         "cdnjs.cloudflare.com",
         "maxcdn.bootstrapcdn.com",
         "www.google-analytics.com"
       ],
       "style-src": [
-        "ajax.googleapis.com",
         "cdnjs.cloudflare.com",
         "fonts.googleapis.com",
         "maxcdn.bootstrapcdn.com"

--- a/src/LondonTravel.Site/karma.conf.js
+++ b/src/LondonTravel.Site/karma.conf.js
@@ -11,7 +11,7 @@ module.exports = function (config) {
         frameworks: ["jasmine", "karma-typescript"],
 
         files: [
-            "https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js",
+            "https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js",
             "assets/scripts/**/*.ts"
         ],
 

--- a/src/LondonTravel.Site/wwwroot/bad-request.html
+++ b/src/LondonTravel.Site/wwwroot/bad-request.html
@@ -53,7 +53,7 @@
         </footer>
     </div>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/flatly/bootstrap.min.css" integrity="sha384-+ENW/yibaokMnme+vBLnHMphUYxHs34h9lpdbSLuAwGkOKFRl4C34WkjazBtb7eT" crossorigin="anonymous" />
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous" defer></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous" defer></script>
 </body>
 </html>

--- a/src/LondonTravel.Site/wwwroot/error.html
+++ b/src/LondonTravel.Site/wwwroot/error.html
@@ -53,7 +53,7 @@
         </footer>
     </div>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/flatly/bootstrap.min.css" integrity="sha384-+ENW/yibaokMnme+vBLnHMphUYxHs34h9lpdbSLuAwGkOKFRl4C34WkjazBtb7eT" crossorigin="anonymous" />
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous" defer></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous" defer></script>
 </body>
 </html>

--- a/src/LondonTravel.Site/wwwroot/not-found.html
+++ b/src/LondonTravel.Site/wwwroot/not-found.html
@@ -53,7 +53,7 @@
         </footer>
     </div>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/flatly/bootstrap.min.css" integrity="sha384-+ENW/yibaokMnme+vBLnHMphUYxHs34h9lpdbSLuAwGkOKFRl4C34WkjazBtb7eT" crossorigin="anonymous" />
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous" defer></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Load jQuery from `cdnjs.cloudflare.com` instead of `ajax.googleapis.com` to reduce the number of different domains resources are loaded from.