### PR TITLE
Add code coverage

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -4,7 +4,8 @@
     [Parameter(Mandatory = $false)][string] $VersionSuffix = "",
     [Parameter(Mandatory = $false)][string] $OutputPath = "",
     [Parameter(Mandatory = $false)][switch] $PatchVersion,
-    [Parameter(Mandatory = $false)][switch] $SkipTests
+    [Parameter(Mandatory = $false)][switch] $SkipTests,
+    [Parameter(Mandatory = $false)][switch] $DisableCodeCoverage
 )
 
 $ErrorActionPreference = "Stop"
@@ -48,7 +49,7 @@ if ($installDotNetSdk -eq $true) {
     }
 
     $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
-    $dotnet = Join-Path "$env:DOTNET_INSTALL_DIR" "dotnet"
+    $dotnet = Join-Path "$env:DOTNET_INSTALL_DIR" "dotnet.exe"
 }
 else {
     $dotnet = "dotnet"
@@ -64,7 +65,35 @@ function DotNetRestore {
 
 function DotNetTest {
     param([string]$Project)
-    & $dotnet test $Project --output $OutputPath --framework $framework
+
+    if ($DisableCodeCoverage -eq $true) {
+        & $dotnet test $Project --output $OutputPath --framework $framework
+    }
+    else {
+
+        if ($installDotNetSdk -eq $true) {
+            $dotnetPath = $dotnet
+        } else {
+            $dotnetPath = (Get-Command "dotnet.exe").Source
+        }
+
+        $nugetPath = Join-Path $env:USERPROFILE ".nuget\packages"
+        $openCoverVersion = "4.6.519"
+        $openCoverPath = Join-Path $nugetPath "OpenCover\$openCoverVersion\tools\OpenCover.Console.exe"
+        $coverageOutput = Join-Path $OutputPath "code-coverage.xml"
+
+        & $openCoverPath `
+            `"-target:$dotnetPath`" `
+            `"-targetargs:test $Project --output $OutputPath`" `
+            -output:$coverageOutput `
+            -hideskipped:All `
+            -mergebyhash `
+            -oldstyle `
+            -register:user `
+            -skipautoprops `
+            `"-filter:+[LondonTravel.Site]* -[LondonTravel.Site.Tests]*`"
+    }
+
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet test failed with exit code $LASTEXITCODE"
     }

--- a/LondonTravel.Site.Common.props
+++ b/LondonTravel.Site.Common.props
@@ -7,8 +7,6 @@
     <CodeAnalysisRuleSet>../../LondonTravel.Site.ruleset</CodeAnalysisRuleSet>
     <Company>https://github.com/martincostello/alexa-london-travel-site</Company>
     <Copyright>Martin Costello (c) 2017</Copyright>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>embedded</DebugType>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 | | Linux | Windows |
 |:-:|:-:|:-:|
-| **Build Status** | [![Build status](https://img.shields.io/travis/martincostello/alexa-london-travel-site/master.svg)](https://travis-ci.org/martincostello/alexa-london-travel-site) | [![Build status](https://img.shields.io/appveyor/ci/martincostello/alexa-london-travel-site/master.svg)](https://ci.appveyor.com/project/martincostello/alexa-london-travel-site) |
+| **Build Status** | [![Build status](https://img.shields.io/travis/martincostello/alexa-london-travel-site/master.svg)](https://travis-ci.org/martincostello/alexa-london-travel-site) | [![Build status](https://img.shields.io/appveyor/ci/martincostello/alexa-london-travel-site/master.svg)](https://ci.appveyor.com/project/martincostello/alexa-london-travel-site) [![codecov](https://codecov.io/gh/martincostello/alexa-london-travel-site/branch/master/graph/badge.svg)](https://codecov.io/gh/martincostello/alexa-london-travel-site) |
 | **Build History** | [![Build history](https://buildstats.info/travisci/chart/martincostello/alexa-london-travel-site?branch=master&includeBuildsFromPullRequest=false)](https://travis-ci.org/martincostello/alexa-london-travel-site) |  [![Build history](https://buildstats.info/appveyor/chart/martincostello/alexa-london-travel-site?branch=master&includeBuildsFromPullRequest=false)](https://ci.appveyor.com/project/martincostello/alexa-london-travel-site) |
 
 ## Overview

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,14 @@ install:
 build_script:
   - ps: .\Build.ps1
 
+after_build:
+    - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
+    - pip install codecov
+    - codecov -f "artifacts\code-coverage.xml"
+
 artifacts:
   - path: artifacts\publish
+  - path: artifacts\code-coverage.xml
 
 nuget:
   disable_publish_on_pr: true

--- a/src/LondonTravel.Site/LondonTravel.Site.csproj
+++ b/src/LondonTravel.Site/LondonTravel.Site.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\LondonTravel.Site.Common.props" />
   <PropertyGroup>
+    <DebugType>full</DebugType>
     <Description>https://londontravel.martincostello.com/</Description>
     <OutputType>Exe</OutputType>
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
@@ -9,6 +10,9 @@
     <Summary>Website for the London Travel Amazon Alexa skill.</Summary>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <UserSecretsId>londontravel.martincostello.com</UserSecretsId>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyVersion.cs;..\..\CommonAssemblyInfo.cs" />

--- a/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
+++ b/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.10" />
+    <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="Shouldly" Version="2.8.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="xunit" Version="2.2.0" />


### PR DESCRIPTION
Add code coverage to tests using [OpenCover](https://github.com/OpenCover/opencover) and submit to [codecov.io](https://codecov.io/gh/martincostello/alexa-london-travel-site) from AppVeyor builds.