### PR TITLE
Add document count resource

### DIFF
--- a/src/LondonTravel.Site/Controllers/ApiController.cs
+++ b/src/LondonTravel.Site/Controllers/ApiController.cs
@@ -58,7 +58,7 @@ namespace MartinCostello.LondonTravel.Site.Controllers
         /// <returns>
         /// The result for the <c>/api/_count</c> action.
         /// </returns>
-        [Authorize(Roles = "administrator")]
+        [Authorize(Roles = "ADMINISTRATOR")]
         [HttpGet]
         [Produces("application/json")]
         [Route("_count")]

--- a/src/LondonTravel.Site/Controllers/ApiController.cs
+++ b/src/LondonTravel.Site/Controllers/ApiController.cs
@@ -10,6 +10,7 @@ namespace MartinCostello.LondonTravel.Site.Controllers
     using System.Threading;
     using System.Threading.Tasks;
     using Identity;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
@@ -49,6 +50,28 @@ namespace MartinCostello.LondonTravel.Site.Controllers
             _client = client;
             _telemetry = telemetry;
             _logger = logger;
+        }
+
+        /// <summary>
+        /// Gets the result for the <c>/api/_count</c> action.
+        /// </summary>
+        /// <returns>
+        /// The result for the <c>/api/_count</c> action.
+        /// </returns>
+        [Authorize(Roles = "administrator")]
+        [HttpGet]
+        [Produces("application/json")]
+        [Route("_count")]
+        public async Task<IActionResult> GetDocumentCount()
+        {
+            long count = await _client.GetDocumentCountAsync();
+
+            var value = new
+            {
+                count = count
+            };
+
+            return Ok(value);
         }
 
         /// <summary>

--- a/src/LondonTravel.Site/Identity/UserClaimsPrincipalFactory.cs
+++ b/src/LondonTravel.Site/Identity/UserClaimsPrincipalFactory.cs
@@ -30,9 +30,8 @@ namespace MartinCostello.LondonTravel.Site.Identity
         public async override Task<ClaimsPrincipal> CreateAsync(LondonTravelUser user)
         {
             var principal = await base.CreateAsync(user);
-            var identity = principal.Identity as ClaimsIdentity;
 
-            if (identity != null)
+            if (principal.Identity is ClaimsIdentity identity)
             {
                 foreach (LondonTravelRole role in user?.RoleClaims)
                 {

--- a/src/LondonTravel.Site/Identity/UserStore.cs
+++ b/src/LondonTravel.Site/Identity/UserStore.cs
@@ -25,7 +25,7 @@ namespace MartinCostello.LondonTravel.Site.Identity
         /// <summary>
         /// The issuer to use for roles.
         /// </summary>
-        private const string RoleClaimIssuer = "london-travel";
+        private const string RoleClaimIssuer = "https://londontravel.martincostello.com/";
 
         /// <summary>
         /// The <see cref="IDocumentClient"/> to use. This field is read-only.

--- a/src/LondonTravel.Site/Identity/UserStore.cs
+++ b/src/LondonTravel.Site/Identity/UserStore.cs
@@ -6,6 +6,7 @@ namespace MartinCostello.LondonTravel.Site.Identity
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Security.Claims;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Identity;
@@ -18,8 +19,14 @@ namespace MartinCostello.LondonTravel.Site.Identity
         IUserStore<LondonTravelUser>,
         IUserEmailStore<LondonTravelUser>,
         IUserLoginStore<LondonTravelUser>,
+        IUserRoleStore<LondonTravelUser>,
         IUserSecurityStampStore<LondonTravelUser>
     {
+        /// <summary>
+        /// The issuer to use for roles.
+        /// </summary>
+        private const string RoleClaimIssuer = "london-travel";
+
         /// <summary>
         /// The <see cref="IDocumentClient"/> to use. This field is read-only.
         /// </summary>
@@ -385,6 +392,76 @@ namespace MartinCostello.LondonTravel.Site.Identity
             {
                 return ResultForError("Conflict", "The user could not be updated as the ETag value is out-of-date.");
             }
+        }
+
+        /// <inheritdoc />
+        public Task AddToRoleAsync(LondonTravelUser user, string roleName, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task<IList<string>> GetRolesAsync(LondonTravelUser user, CancellationToken cancellationToken)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            IList<string> roles = Array.Empty<string>();
+
+            if (user.RoleClaims?.Count > 0)
+            {
+                roles = user.RoleClaims
+                    .Where((p) => string.Equals(p.Issuer, RoleClaimIssuer, StringComparison.Ordinal))
+                    .Where((p) => string.Equals(p.ClaimType, ClaimTypes.Role, StringComparison.Ordinal))
+                    .Where((p) => string.Equals(p.ValueType, ClaimValueTypes.String, StringComparison.Ordinal))
+                    .Where((p) => !string.IsNullOrEmpty(p.Value))
+                    .Select((p) => p.Value)
+                    .ToArray();
+            }
+
+            return Task.FromResult(roles);
+        }
+
+        /// <inheritdoc />
+        public Task<IList<LondonTravelUser>> GetUsersInRoleAsync(string roleName, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task<bool> IsInRoleAsync(LondonTravelUser user, string roleName, CancellationToken cancellationToken)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            if (roleName == null)
+            {
+                throw new ArgumentNullException(nameof(roleName));
+            }
+
+            bool isInRole = false;
+
+            if (user.RoleClaims?.Count > 0)
+            {
+                isInRole = user.RoleClaims
+                    .Where((p) => string.Equals(p.Issuer, RoleClaimIssuer, StringComparison.Ordinal))
+                    .Where((p) => string.Equals(p.ClaimType, ClaimTypes.Role, StringComparison.Ordinal))
+                    .Where((p) => string.Equals(p.ValueType, ClaimValueTypes.String, StringComparison.Ordinal))
+                    .Where((p) => string.Equals(p.Value, roleName, StringComparison.Ordinal))
+                    .Any();
+            }
+
+            return Task.FromResult(isInRole);
+        }
+
+        /// <inheritdoc />
+        public Task RemoveFromRoleAsync(LondonTravelUser user, string roleName, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/src/LondonTravel.Site/Services/Data/IDocumentClient.cs
+++ b/src/LondonTravel.Site/Services/Data/IDocumentClient.cs
@@ -61,6 +61,14 @@ namespace MartinCostello.LondonTravel.Site.Services.Data
             where T : class;
 
         /// <summary>
+        /// Gets the count of documents in the collection as an asynchronous operation.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the count of documents in the collection.
+        /// </returns>
+        Task<long> GetDocumentCountAsync();
+
+        /// <summary>
         /// Replaces the document with the specified Id with the
         /// specified new document as an asynchronous operation.
         /// </summary>

--- a/tests/LondonTravel.Site.Tests/Identity/UserStoreTests.cs
+++ b/tests/LondonTravel.Site.Tests/Identity/UserStoreTests.cs
@@ -431,10 +431,10 @@ namespace MartinCostello.LondonTravel.Site.Identity
             // Arrange
             var user = new LondonTravelUser();
 
-            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "admin", ClaimValueTypes.String, "london-travel")));
-            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "not-a-string", ClaimValueTypes.Email, "london-travel")));
+            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "admin", ClaimValueTypes.String, "https://londontravel.martincostello.com/")));
+            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "not-a-string", ClaimValueTypes.Email, "https://londontravel.martincostello.com/")));
             user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "wrong-issuer", ClaimValueTypes.String, "google")));
-            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, string.Empty, ClaimValueTypes.String, "london-travel")));
+            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, string.Empty, ClaimValueTypes.String, "https://londontravel.martincostello.com/")));
 
             var expected = new[]
             {
@@ -458,8 +458,8 @@ namespace MartinCostello.LondonTravel.Site.Identity
             var user = new LondonTravelUser();
             var cancellationToken = CancellationToken.None;
 
-            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "admin", ClaimValueTypes.String, "london-travel")));
-            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "not-a-string", ClaimValueTypes.Email, "london-travel")));
+            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "admin", ClaimValueTypes.String, "https://londontravel.martincostello.com/")));
+            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "not-a-string", ClaimValueTypes.Email, "https://londontravel.martincostello.com/")));
             user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "wrong-issuer", ClaimValueTypes.String, "google")));
 
             var expected = new[]

--- a/tests/LondonTravel.Site.Tests/Identity/UserStoreTests.cs
+++ b/tests/LondonTravel.Site.Tests/Identity/UserStoreTests.cs
@@ -1,0 +1,491 @@
+﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Identity
+{
+    using System;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using MartinCostello.LondonTravel.Site.Services.Data;
+    using Microsoft.AspNetCore.Identity;
+    using Moq;
+    using Shouldly;
+    using Xunit;
+
+    public static class UserStoreTests
+    {
+        [Fact]
+        public static async Task Methods_Validate_Parameters()
+        {
+            // Arrange
+            var user = new LondonTravelUser();
+            var login = new UserLoginInfo("loginProvider", "providerKey", "displayName");
+            var cancellationToken = CancellationToken.None;
+
+            UserStore target = CreateStore();
+
+            // Act and Assert
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.AddLoginAsync(null, login, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("login", () => target.AddLoginAsync(user, null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.CreateAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.DeleteAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("normalizedEmail", () => target.FindByEmailAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("userId", () => target.FindByIdAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("loginProvider", () => target.FindByLoginAsync(null, "b", cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("providerKey", () => target.FindByLoginAsync("a", null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("normalizedUserName", () => target.FindByNameAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.GetEmailAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.GetEmailConfirmedAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.GetLoginsAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.GetNormalizedEmailAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.GetNormalizedUserNameAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.GetRolesAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.GetSecurityStampAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.GetUserIdAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.GetUserNameAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.RemoveLoginAsync(null, "a", "b", cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("loginProvider", () => target.RemoveLoginAsync(user, null, "b", cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("providerKey", () => target.RemoveLoginAsync(user, "a", null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.SetEmailAsync(null, "a", cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.SetEmailConfirmedAsync(null, true, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.SetNormalizedEmailAsync(null, "a", cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.SetNormalizedUserNameAsync(null, "a", cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.SetSecurityStampAsync(null, "a", cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.SetUserNameAsync(null, "a", cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.SetEmailAsync(null, "a", cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.UpdateAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.GetRolesAsync(null, cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("user", () => target.IsInRoleAsync(null, "a", cancellationToken));
+            await Assert.ThrowsAsync<ArgumentNullException>("roleName", () => target.IsInRoleAsync(user, null, cancellationToken));
+        }
+
+        [Fact]
+        public static async Task Methods_That_Are_Not_Implemented_Throw()
+        {
+            // Arrange
+            var user = new LondonTravelUser();
+            var roleName = "RoleName";
+            var cancellationToken = CancellationToken.None;
+
+            UserStore target = CreateStore();
+
+            // Act and Assert
+            await Assert.ThrowsAsync<NotImplementedException>(() => target.AddToRoleAsync(user, roleName, cancellationToken));
+            await Assert.ThrowsAsync<NotImplementedException>(() => target.GetUsersInRoleAsync(roleName, cancellationToken));
+            await Assert.ThrowsAsync<NotImplementedException>(() => target.RemoveFromRoleAsync(user, roleName, cancellationToken));
+        }
+
+        [Fact]
+        public static async Task AddLoginAsync_Throws_If_Login_Exists_For_Provider()
+        {
+            // Arrange
+            var user = new LondonTravelUser();
+            user.Logins.Add(new LondonTravelLoginInfo() { LoginProvider = "acme" });
+
+            var login = new UserLoginInfo("acme", "providerKey", "displayName");
+
+            UserStore target = CreateStore();
+
+            // Act and Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => target.AddLoginAsync(user, login, CancellationToken.None));
+        }
+
+        [Fact]
+        public static async Task AddLoginAsync_Adds_Login()
+        {
+            // Arrange
+            var user = new LondonTravelUser();
+            var login = new UserLoginInfo("acme", "providerKey", "displayName");
+
+            UserStore target = CreateStore();
+
+            // Act
+            await target.AddLoginAsync(user, login, CancellationToken.None);
+
+            // Assert
+            user.Logins.ShouldNotBeNull();
+            user.Logins.ShouldNotBeEmpty();
+            user.Logins.Count.ShouldBe(1);
+
+            var added = user.Logins[0];
+
+            added.ShouldNotBeNull();
+            added.LoginProvider.ShouldBe(login.LoginProvider);
+            added.ProviderDisplayName.ShouldBe(login.ProviderDisplayName);
+            added.ProviderKey.ShouldBe(login.ProviderKey);
+        }
+
+        [Fact]
+        public static async Task CreateAsync_Creates_User()
+        {
+            // Arrange
+            var user = new LondonTravelUser();
+
+            var mock = new Mock<IDocumentClient>();
+
+            mock.Setup((p) => p.CreateAsync(user))
+                .ReturnsAsync("MyUserId");
+
+            UserStore target = CreateStore(mock.Object);
+
+            // Act
+            var actual = await target.CreateAsync(user, CancellationToken.None);
+
+            // Assert
+            actual.ShouldBe(IdentityResult.Success);
+
+            user.Id.ShouldNotBeNullOrEmpty();
+            user.Id.ShouldBe("MyUserId");
+        }
+
+        [Fact]
+        public static async Task DeleteAsync_If_User_Exists()
+        {
+            // Arrange
+            var user = new LondonTravelUser()
+            {
+                Id = "MyUserId"
+            };
+
+            var mock = new Mock<IDocumentClient>();
+
+            mock.Setup((p) => p.DeleteAsync(user.Id))
+                .ReturnsAsync(true);
+
+            UserStore target = CreateStore(mock.Object);
+
+            // Act
+            var actual = await target.DeleteAsync(user, CancellationToken.None);
+
+            // Assert
+            actual.ShouldBe(IdentityResult.Success);
+        }
+
+        [Fact]
+        public static async Task DeleteAsync_If_User_Does_Not_Exist()
+        {
+            // Arrange
+            var user = new LondonTravelUser()
+            {
+                Id = "MyUserId"
+            };
+
+            var mock = new Mock<IDocumentClient>();
+
+            mock.Setup((p) => p.DeleteAsync(user.Id))
+                .ReturnsAsync(false);
+
+            UserStore target = CreateStore(mock.Object);
+
+            // Act
+            var actual = await target.DeleteAsync(user, CancellationToken.None);
+
+            // Assert
+            actual.ShouldNotBe(IdentityResult.Success);
+            actual.Errors.ShouldNotBeEmpty();
+            actual.Errors.First().Code.ShouldBe("UserNotFound");
+        }
+
+        [Fact]
+        public static async Task DeleteAsync_Throws_If_No_User_Id()
+        {
+            // Arrange
+            var user = new LondonTravelUser()
+            {
+                Id = string.Empty,
+            };
+
+            UserStore target = CreateStore();
+
+            // Act and Assert
+            await Assert.ThrowsAsync<ArgumentException>("user", () => target.DeleteAsync(user, CancellationToken.None));
+        }
+
+        [Fact]
+        public static async Task GetEmailAsync_Returns_Correct_Value()
+        {
+            // Arrange
+            var user = new LondonTravelUser()
+            {
+                Email = "user@domain.com",
+            };
+
+            UserStore target = CreateStore();
+
+            // Act
+            var actual = await target.GetEmailAsync(user, CancellationToken.None);
+
+            // Assert
+            actual.ShouldBe("user@domain.com");
+        }
+
+        [Fact]
+        public static async Task GetEmailConfirmedAsync_Returns_Correct_Value()
+        {
+            // Arrange
+            var user = new LondonTravelUser()
+            {
+                EmailConfirmed = true,
+            };
+
+            UserStore target = CreateStore();
+
+            // Act
+            var actual = await target.GetEmailConfirmedAsync(user, CancellationToken.None);
+
+            // Assert
+            actual.ShouldBeTrue();
+        }
+
+        [Fact]
+        public static async Task GetNormalizedEmailAsync_Returns_Correct_Value()
+        {
+            // Arrange
+            var user = new LondonTravelUser()
+            {
+                EmailNormalized = "user@domain.com",
+            };
+
+            UserStore target = CreateStore();
+
+            // Act
+            var actual = await target.GetNormalizedEmailAsync(user, CancellationToken.None);
+
+            // Assert
+            actual.ShouldBe("user@domain.com");
+        }
+
+        [Fact]
+        public static async Task GetNormalizedUserNameAsync_Returns_Correct_Value()
+        {
+            // Arrange
+            var user = new LondonTravelUser()
+            {
+                UserNameNormalized = "user.name",
+            };
+
+            UserStore target = CreateStore();
+
+            // Act
+            var actual = await target.GetNormalizedUserNameAsync(user, CancellationToken.None);
+
+            // Assert
+            actual.ShouldBe("user.name");
+        }
+
+        [Fact]
+        public static async Task GetSecurityStampAsync_Returns_Correct_Value()
+        {
+            // Arrange
+            var user = new LondonTravelUser()
+            {
+                SecurityStamp = "MySecurityStamp",
+            };
+
+            UserStore target = CreateStore();
+
+            // Act
+            var actual = await target.GetSecurityStampAsync(user, CancellationToken.None);
+
+            // Assert
+            actual.ShouldBe("MySecurityStamp");
+        }
+
+        [Fact]
+        public static async Task GetUserIdAsync_Returns_Correct_Value()
+        {
+            // Arrange
+            var user = new LondonTravelUser()
+            {
+                Id = "123",
+            };
+
+            UserStore target = CreateStore();
+
+            // Act
+            var actual = await target.GetUserIdAsync(user, CancellationToken.None);
+
+            // Assert
+            actual.ShouldBe("123");
+        }
+
+        [Fact]
+        public static async Task GetUserNameAsync_Returns_Correct_Value()
+        {
+            // Arrange
+            var user = new LondonTravelUser()
+            {
+                UserName = "user.name",
+            };
+
+            UserStore target = CreateStore();
+
+            // Act
+            var actual = await target.GetUserNameAsync(user, CancellationToken.None);
+
+            // Assert
+            actual.ShouldBe("user.name");
+        }
+
+        [Fact]
+        public static async Task SetEmailAsync_Sets_Correct_Property()
+        {
+            // Arrange
+            var expected = "user@domain.com";
+            var user = new LondonTravelUser();
+
+            UserStore target = CreateStore();
+
+            // Act
+            await target.SetEmailAsync(user, expected, CancellationToken.None);
+
+            // Assert
+            user.Email.ShouldBe(expected);
+        }
+
+        [Fact]
+        public static async Task SetEmailConfirmedAsync_Sets_Correct_Property()
+        {
+            // Arrange
+            var expected = true;
+            var user = new LondonTravelUser();
+
+            UserStore target = CreateStore();
+
+            // Act
+            await target.SetEmailConfirmedAsync(user, expected, CancellationToken.None);
+
+            // Assert
+            user.EmailConfirmed.ShouldBe(expected);
+        }
+
+        [Fact]
+        public static async Task SetNormalizedEmailAsync_Sets_Correct_Property()
+        {
+            // Arrange
+            var expected = "user@domain.com";
+            var user = new LondonTravelUser();
+
+            UserStore target = CreateStore();
+
+            // Act
+            await target.SetNormalizedEmailAsync(user, expected, CancellationToken.None);
+
+            // Assert
+            user.EmailNormalized.ShouldBe(expected);
+        }
+
+        [Fact]
+        public static async Task SetNormalizedUserNameAsync_Sets_Correct_Property()
+        {
+            // Arrange
+            var expected = "user.name";
+            var user = new LondonTravelUser();
+
+            UserStore target = CreateStore();
+
+            // Act
+            await target.SetNormalizedUserNameAsync(user, expected, CancellationToken.None);
+
+            // Assert
+            user.UserNameNormalized.ShouldBe(expected);
+        }
+
+        [Fact]
+        public static async Task SetSecurityStampAsync_Sets_Correct_Property()
+        {
+            // Arrange
+            var expected = "MySecurityStamp";
+            var user = new LondonTravelUser();
+
+            UserStore target = CreateStore();
+
+            // Act
+            await target.SetSecurityStampAsync(user, expected, CancellationToken.None);
+
+            // Assert
+            user.SecurityStamp.ShouldBe(expected);
+        }
+
+        [Fact]
+        public static async Task SetUserNameAsync_Sets_Correct_Property()
+        {
+            // Arrange
+            var expected = "user.name";
+            var user = new LondonTravelUser();
+
+            UserStore target = CreateStore();
+
+            // Act
+            await target.SetUserNameAsync(user, expected, CancellationToken.None);
+
+            // Assert
+            user.UserName.ShouldBe(expected);
+        }
+
+        [Fact]
+        public static async Task GetRolesAsync_Returns_Expected_Names()
+        {
+            // Arrange
+            var user = new LondonTravelUser();
+
+            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "admin", ClaimValueTypes.String, "london-travel")));
+            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "not-a-string", ClaimValueTypes.Email, "london-travel")));
+            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "wrong-issuer", ClaimValueTypes.String, "google")));
+            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, string.Empty, ClaimValueTypes.String, "london-travel")));
+
+            var expected = new[]
+            {
+                "admin"
+            };
+
+            UserStore target = CreateStore();
+
+            // Act
+            var actual = await target.GetRolesAsync(user,  CancellationToken.None);
+
+            // Assert
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expected);
+        }
+
+        [Fact]
+        public static async Task IsInRoleAsync_Returns_Expected_Value()
+        {
+            // Arrange
+            var user = new LondonTravelUser();
+            var cancellationToken = CancellationToken.None;
+
+            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "admin", ClaimValueTypes.String, "london-travel")));
+            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "not-a-string", ClaimValueTypes.Email, "london-travel")));
+            user.RoleClaims.Add(LondonTravelRole.FromClaim(new Claim(ClaimTypes.Role, "wrong-issuer", ClaimValueTypes.String, "google")));
+
+            var expected = new[]
+            {
+                "admin"
+            };
+
+            UserStore target = CreateStore();
+
+            // Act and Assert
+            (await target.IsInRoleAsync(user, "admin", cancellationToken)).ShouldBeTrue();
+            (await target.IsInRoleAsync(user, "not-a-role", cancellationToken)).ShouldBeFalse();
+            (await target.IsInRoleAsync(user, "not-a-string", cancellationToken)).ShouldBeFalse();
+            (await target.IsInRoleAsync(user, "wrong-issuer", cancellationToken)).ShouldBeFalse();
+            (await target.IsInRoleAsync(user, string.Empty, cancellationToken)).ShouldBeFalse();
+
+            // Arrange
+            user.RoleClaims = null;
+
+            // Act and Assert
+            (await target.IsInRoleAsync(user, "admin", cancellationToken)).ShouldBeFalse();
+        }
+
+        private static UserStore CreateStore(IDocumentClient client = null)
+        {
+            return new UserStore(client ?? Mock.Of<IDocumentClient>());
+        }
+    }
+}


### PR DESCRIPTION
Add a resource that allows authorised users with the appropriate role to view the count of documents (i.e. users) in the Azure Cosmos DB collection containing the registered users.

For a user to access the resource (which is protected to prevent abuse of the request quota to DocumentDB), the signed-in user must possess a role equivalent to:

```json
{
  "issuer": "https://londontravel.martincostello.com/",
  "claimType": "http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
  "valueType": "http://www.w3.org/2001/XMLSchema#string",
  "value": "ADMINISTRATOR"
}
```