### PR TITLE
Test coverage improvements

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -1,4 +1,4 @@
-﻿param(
+param(
     [Parameter(Mandatory = $false)][switch] $RestorePackages,
     [Parameter(Mandatory = $false)][string] $Configuration = "Release",
     [Parameter(Mandatory = $false)][string] $VersionSuffix = "",
@@ -77,9 +77,15 @@ function DotNetTest {
         }
 
         $nugetPath = Join-Path $env:USERPROFILE ".nuget\packages"
+
         $openCoverVersion = "4.6.519"
         $openCoverPath = Join-Path $nugetPath "OpenCover\$openCoverVersion\tools\OpenCover.Console.exe"
+
+        $reportGeneratorVersion = "3.0.2"
+        $reportGeneratorPath = Join-Path $nugetPath "ReportGenerator\$reportGeneratorVersion\tools\ReportGenerator.exe"
+
         $coverageOutput = Join-Path $OutputPath "code-coverage.xml"
+        $reportOutput = Join-Path $OutputPath "coverage"
 
         & $openCoverPath `
             `"-target:$dotnetPath`" `
@@ -91,6 +97,13 @@ function DotNetTest {
             -register:user `
             -skipautoprops `
             `"-filter:+[LondonTravel.Site]* -[LondonTravel.Site.Tests]*`"
+
+        if ($LASTEXITCODE -eq 0) {
+            & $reportGeneratorPath `
+                `"-reports:$coverageOutput`" `
+                `"-targetdir:$reportOutput`" `
+                -verbosity:Warning
+        }
     }
 
     if ($LASTEXITCODE -ne 0) {

--- a/Build.ps1
+++ b/Build.ps1
@@ -91,6 +91,7 @@ function DotNetTest {
             `"-target:$dotnetPath`" `
             `"-targetargs:test $Project --output $OutputPath`" `
             -output:$coverageOutput `
+            -excludebyattribute:*.ExcludeFromCodeCoverage* `
             -hideskipped:All `
             -mergebyhash `
             -oldstyle `

--- a/src/LondonTravel.Site/Controllers/ErrorController.cs
+++ b/src/LondonTravel.Site/Controllers/ErrorController.cs
@@ -79,7 +79,9 @@ namespace MartinCostello.LondonTravel.Site.Controllers
         {
             int httpCode = id ?? 500;
 
-            if (!Enum.IsDefined(typeof(HttpStatusCode), (HttpStatusCode)httpCode))
+            if (!Enum.IsDefined(typeof(HttpStatusCode), (HttpStatusCode)httpCode) ||
+                id < 400 ||
+                id > 599)
             {
                 httpCode = (int)HttpStatusCode.InternalServerError;
             }

--- a/src/LondonTravel.Site/Extensions/IServiceCollectionExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/IServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ namespace MartinCostello.LondonTravel.Site.Extensions
     using System;
     using System.IO;
     using System.Linq;
+    using System.Net.Http;
     using System.Reflection;
     using Identity.Amazon;
     using MartinCostello.LondonTravel.Site.Identity;
@@ -25,6 +26,39 @@ namespace MartinCostello.LondonTravel.Site.Extensions
     /// </summary>
     public static class IServiceCollectionExtensions
     {
+        /// <summary>
+        /// Adds <see cref="HttpClient"/> to the services.
+        /// </summary>
+        /// <param name="value">The <see cref="IServiceCollection"/> to add HTTP client to.</param>
+        /// <returns>
+        /// The value specified by <paramref name="value"/>.
+        /// </returns>
+        public static IServiceCollection AddHttpClient(this IServiceCollection value)
+        {
+            return value.AddTransient(
+                (p) =>
+                {
+                    HttpMessageHandler handler = new HttpClientHandler();
+                    var handlers = p.GetServices<DelegatingHandler>().ToList();
+
+                    if (handlers.Count > 0)
+                    {
+                        var previous = handlers.First();
+                        previous.InnerHandler = handler;
+
+                        foreach (var next in handlers.Skip(1))
+                        {
+                            next.InnerHandler = previous;
+                            previous = next;
+                        }
+
+                        handler = previous;
+                    }
+
+                    return new HttpClient(handler);
+                });
+        }
+
         /// <summary>
         /// Adds Swagger to the services.
         /// </summary>

--- a/src/LondonTravel.Site/Identity/RoleStore.cs
+++ b/src/LondonTravel.Site/Identity/RoleStore.cs
@@ -11,6 +11,7 @@ namespace MartinCostello.LondonTravel.Site.Identity
     /// <summary>
     /// A class representing a custom implementation of <see cref="IRoleStore{LondonTravelRole}"/>. This class cannot be inherited.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public sealed class RoleStore : IRoleStore<LondonTravelRole>
     {
         /// <inheritdoc />

--- a/src/LondonTravel.Site/LondonTravel.Site.csproj
+++ b/src/LondonTravel.Site/LondonTravel.Site.csproj
@@ -24,8 +24,8 @@
     <EmbeddedResource Update="SiteResources.resx" Generator="" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.2.0" />
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.2.0" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.4.0" />
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.4.0" />
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
   </ItemGroup>
@@ -37,20 +37,20 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.5.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.5.1" />
     <PackageReference Include="Microsoft.Azure.KeyVault.WebKey" Version="2.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NodaTime" Version="2.2.0" />
     <PackageReference Include="Serilog" Version="2.5.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.4.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.2.1" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
-    <PackageReference Include="Serilog.Sinks.UDP" Version="3.0.0" />
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.1.2" PrivateAssets="All" />
+    <PackageReference Include="Serilog.Sinks.UDP" Version="3.3.0" />
+    <PackageReference Include="SourceLink.Create.GitHub" Version="2.4.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="1.0.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="8.3.0" />
+    <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
   </ItemGroup>
   <Target Name="BundleAssets" BeforeTargets="PrepareForPublish">
     <Exec Command="npm install --loglevel=error" Condition=" '$(InstallWebPackages)' == 'true' " />

--- a/src/LondonTravel.Site/LondonTravel.Site.csproj
+++ b/src/LondonTravel.Site/LondonTravel.Site.csproj
@@ -24,8 +24,6 @@
     <EmbeddedResource Update="SiteResources.resx" Generator="" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.4.0" />
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.4.0" />
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
   </ItemGroup>
@@ -47,7 +45,6 @@
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.2.1" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.UDP" Version="3.3.0" />
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.4.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="1.0.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />

--- a/src/LondonTravel.Site/StartupBase.cs
+++ b/src/LondonTravel.Site/StartupBase.cs
@@ -5,7 +5,6 @@ namespace MartinCostello.LondonTravel.Site
 {
     using System;
     using System.Globalization;
-    using System.Net.Http;
     using Autofac;
     using Autofac.Extensions.DependencyInjection;
     using Extensions;
@@ -206,7 +205,7 @@ namespace MartinCostello.LondonTravel.Site
             services.AddScoped((p) => p.GetRequiredService<SiteOptions>().Tfl);
 
             services.AddScoped<SiteResources>();
-            services.AddTransient<HttpClient>();
+            services.AddHttpClient();
             services.AddTransient<ITflService, TflService>();
 
             services

--- a/src/LondonTravel.Site/assets/styles/css/travel.css
+++ b/src/LondonTravel.Site/assets/styles/css/travel.css
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Copyright (c) Martin Costello, 2017. All rights reserved.
     Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 */
@@ -30,6 +30,10 @@
 
 .travel-line-dlr {
     border-left-color: #00afad;
+}
+
+.travel-line-elizabeth {
+    border-left-color: #603e99;
 }
 
 .travel-line-hammersmith-city {

--- a/tests/LondonTravel.Site.Tests/Integration/AccountTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/AccountTests.cs
@@ -71,7 +71,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
                 Assert.Null(actual.AlexaToken);
                 Assert.Equal(user.CreatedAt, actual.CreatedAt);
                 Assert.Equal(user.Email, actual.Email);
-                Assert.Equal(false, actual.EmailConfirmed);
+                Assert.False(actual.EmailConfirmed);
                 Assert.NotEmpty(actual.ETag);
                 Assert.Equal(Array.Empty<string>(), actual.FavoriteLines);
                 Assert.Equal(user.GivenName, actual.GivenName);

--- a/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
+++ b/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\src\LondonTravel.Site\LondonTravel.Site.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="JustEat.HttpClientInterception" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Moq" Version="4.7.142" />

--- a/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
+++ b/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
@@ -17,12 +17,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="Moq" Version="4.7.142" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="Shouldly" Version="2.8.2" />
+    <PackageReference Include="Shouldly" Version="2.8.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
+++ b/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Moq" Version="4.7.142" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
+    <PackageReference Include="ReportGenerator" Version="3.0.2" />
     <PackageReference Include="Shouldly" Version="2.8.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="xunit" Version="2.3.0" />


### PR DESCRIPTION
  1. Update NuGet dependencies to their latest versions.
  1. Refactor registration of `HttpClient` to allow for dependency injection of `DelegatingHandler` instances.
  1. Generate a human-readable HTTP code coverage report.
  1. Add more tests for `ErrorController`.
  1. Support the use of `[ExcludeFromCodeCoverage]` with code coverage results/reports.
  1. Add tests for `TflService` using [`JustEat.HttpClientInterception`](https://github.com/justeat/httpclient-interception).
  1. Add a colour to the CSS for representing the Elizabeth Line (Crossrail) - see #153.
  1. Fix incorrect cache key for stop points.
  1. Refactor creation of URLs for the TfL API.
  1. Fix `NullReferenceException` if the `Cache-Control` header is ever not returned by the TfL API.
  1. Fix incorrect HTTP status code mappings for non-error codes for the error page.
  1. Fix incorrect xunit test assert.