### PR TITLE
Improve icon link tags

### DIFF
--- a/src/LondonTravel.Site/Views/Shared/_Links.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Links.cshtml
@@ -3,41 +3,32 @@
     string canonical = Model.Item1;
     SiteOptions options = Model.Item2;
 }
-    <link rel="dns-prefetch" href="https://@options?.ExternalLinks?.Cdn?.Host" />
-    <link rel="dns-prefetch" href="https://az416426.vo.msecnd.net" />
-    <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com" />
-    <link rel="dns-prefetch" href="https://dc.services.visualstudio.com" />
-    <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
-    <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
-    <link rel="dns-prefetch" href="https://maxcdn.bootstrapcdn.com" />
-    <link rel="dns-prefetch" href="https://www.google-analytics.com" />
-    <link rel="dns-prefetch" href="https://www.gravatar.com" />
-    <link rel="preconnect" href="https://@options?.ExternalLinks?.Cdn?.Host" />
-    <link rel="preconnect" href="https://az416426.vo.msecnd.net" />
-    <link rel="preconnect" href="https://cdnjs.cloudflare.com" />
-    <link rel="preconnect" href="https://dc.services.visualstudio.com" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link rel="preconnect" href="https://maxcdn.bootstrapcdn.com" />
-    <link rel="preconnect" href="https://www.google-analytics.com" />
-    <link rel="preconnect" href="https://www.gravatar.com" />
-    <link rel="canonical" href="@canonical" />
-    <link rel="manifest" href="@Url.Content("~/manifest.webmanifest")" />
-    <link rel="sitemap" type="application/xml" href="@Url.Content("~/sitemap.xml")" asp-append-version="true" />
-    <link rel="shortcut icon" type="image/x-icon" href="@Url.CdnContent("favicon.ico", options)" />
-    <link rel="shortcut icon" sizes="196x196" href="@Url.CdnContent("favicon-196x196.png", options)" />
-    <link rel="icon" type="image/png" sizes="16x16" href="@Url.CdnContent("favicon-16x16.png", options)" />
-    <link rel="icon" type="image/png" sizes="32x32" href="@Url.CdnContent("favicon-32x32.png", options)" />
-    <link rel="icon" type="image/png" sizes="57x57" href="@Url.CdnContent("favicon-57x57.png", options)" />
-    <link rel="icon" type="image/png" sizes="72x72" href="@Url.CdnContent("favicon-72x72.png", options)" />
-    <link rel="icon" type="image/png" sizes="96x96" href="@Url.CdnContent("favicon-96x96.png", options)" />
-    <link rel="icon" type="image/png" sizes="120x120" href="@Url.CdnContent("favicon-120x120.png", options)" />
-    <link rel="icon" type="image/png" sizes="128x128" href="@Url.CdnContent("favicon-128x128.png", options)" />
-    <link rel="icon" type="image/png" sizes="144x144" href="@Url.CdnContent("favicon-144x144.png", options)" />
-    <link rel="icon" type="image/png" sizes="152x152" href="@Url.CdnContent("favicon-152x152.png", options)" />
-    <link rel="icon" type="image/png" sizes="180x180" href="@Url.CdnContent("favicon-180x180.png", options)" />
-    <link rel="icon" type="image/png" sizes="192x192" href="@Url.CdnContent("favicon-192x192.png", options)" />
-    <link rel="icon" type="image/png" sizes="195x195" href="@Url.CdnContent("favicon-195x195.png", options)" />
-    <link rel="icon" type="image/png" sizes="196x196" href="@Url.CdnContent("favicon-196x196.png", options)" />
-    <link rel="icon" type="image/png" sizes="228x228" href="@Url.CdnContent("favicon-228x228.png", options)" />
-    <link rel="apple-touch-icon" href="@Url.CdnContent("apple-touch-icon-180x180.png", options)" />
+    <link rel="dns-prefetch" href="https://@options?.ExternalLinks?.Cdn?.Host">
+    <link rel="dns-prefetch" href="https://az416426.vo.msecnd.net">
+    <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
+    <link rel="dns-prefetch" href="https://dc.services.visualstudio.com">
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <link rel="dns-prefetch" href="https://maxcdn.bootstrapcdn.com">
+    <link rel="dns-prefetch" href="https://www.google-analytics.com">
+    <link rel="dns-prefetch" href="https://www.gravatar.com">
+    <link rel="preconnect" href="https://@options?.ExternalLinks?.Cdn?.Host">
+    <link rel="preconnect" href="https://az416426.vo.msecnd.net">
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com">
+    <link rel="preconnect" href="https://dc.services.visualstudio.com">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link rel="preconnect" href="https://maxcdn.bootstrapcdn.com">
+    <link rel="preconnect" href="https://www.google-analytics.com">
+    <link rel="preconnect" href="https://www.gravatar.com">
+    <link rel="canonical" href="@canonical">
+    <link rel="manifest" href="@Url.Content("~/manifest.webmanifest")">
+    <link rel="sitemap" type="application/xml" href="@Url.Content("~/sitemap.xml")" asp-append-version="true">
+    <link rel="shortcut icon" href="@Url.CdnContent("favicon.ico", options)">
+    <link rel="shortcut icon" sizes="16x16" href="@Url.CdnContent("favicon-16x16.png", options)">
+    <link rel="shortcut icon" sizes="32x32" href="@Url.CdnContent("favicon-32x32.png", options)">
+    <link rel="shortcut icon" sizes="96x96" href="@Url.CdnContent("favicon-96x96.png", options)">
+    <link rel="shortcut icon" sizes="152x152" href="@Url.CdnContent("favicon-152x152.png", options)">
+    <link rel="shortcut icon" sizes="192x192" href="@Url.CdnContent("favicon-192x192.png", options)">
+    <link rel="shortcut icon" sizes="196x196" href="@Url.CdnContent("favicon-196x196.png", options)">
+    <link rel="apple-touch-icon" href="@Url.CdnContent("apple-touch-icon-180x180.png", options)">


### PR DESCRIPTION
Improve the icon `<link>` tags by explicitly marking them as shortcut icons and removing some of the sizes.