### PR TITLE
Show user count

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -79,7 +79,7 @@ function DotNetTest {
         $openCoverVersion = "4.6.519"
         $openCoverPath = Join-Path $nugetPath "OpenCover\$openCoverVersion\tools\OpenCover.Console.exe"
 
-        $reportGeneratorVersion = "3.0.2"
+        $reportGeneratorVersion = "3.1.1"
         $reportGeneratorPath = Join-Path $nugetPath "ReportGenerator\$reportGeneratorVersion\tools\ReportGenerator.exe"
 
         $coverageOutput = Join-Path $OutputPath "code-coverage.xml"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <Copyright>Martin Costello (c) $([System.DateTime]::UtcNow.ToString(yyyy))</Copyright>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <GenerateGitMetadata Condition=" '$(CI)' == 'true' and '$(GenerateGitMetadata)' == '' ">true</GenerateGitMetadata>
+    <GenerateGitMetadata Condition=" ('$(CI)' != '' or '$(TF_BUILD)' != '') and '$(GenerateGitMetadata)' == '' ">true</GenerateGitMetadata>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <LangVersion>latest</LangVersion>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/src/LondonTravel.Site/Controllers/AccountController.cs
+++ b/src/LondonTravel.Site/Controllers/AccountController.cs
@@ -30,6 +30,8 @@ namespace MartinCostello.LondonTravel.Site.Controllers
         /// </summary>
         private static readonly string[] AuthenticationSchemesDisabledForAlexa = new[] { "google" };
 
+        //// TODO Move more of the implementation into IAccountService
+
         private readonly UserManager<LondonTravelUser> _userManager;
         private readonly SignInManager<LondonTravelUser> _signInManager;
         private readonly ISiteTelemetry _telemetry;
@@ -269,30 +271,6 @@ namespace MartinCostello.LondonTravel.Site.Controllers
 
                 return View("SignIn");
             }
-        }
-
-        /// <summary>
-        /// Gets the result for the <c>/account/register/</c> action.
-        /// </summary>
-        /// <returns>
-        /// The result for the <c>/account/register/</c> action.
-        /// </returns>
-        [AllowAnonymous]
-        [HttpGet]
-        [Route("register", Name = SiteRoutes.Register)]
-        public IActionResult Register()
-        {
-            if (!_isEnabled)
-            {
-                return NotFound();
-            }
-
-            if (User.Identity.IsAuthenticated)
-            {
-                return RedirectToRoute(SiteRoutes.Home);
-            }
-
-            return View();
         }
 
         private void AddErrors(IdentityResult result)

--- a/src/LondonTravel.Site/Controllers/ErrorController.cs
+++ b/src/LondonTravel.Site/Controllers/ErrorController.cs
@@ -6,6 +6,7 @@ namespace MartinCostello.LondonTravel.Site.Controllers
     using System;
     using System.Net;
     using MartinCostello.LondonTravel.Site.Telemetry;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
 
     /// <summary>
@@ -77,13 +78,13 @@ namespace MartinCostello.LondonTravel.Site.Controllers
         [HttpGet]
         public IActionResult Index(int? id)
         {
-            int httpCode = id ?? 500;
+            int httpCode = id ?? StatusCodes.Status500InternalServerError;
 
             if (!Enum.IsDefined(typeof(HttpStatusCode), (HttpStatusCode)httpCode) ||
-                id < 400 ||
+                id < StatusCodes.Status400BadRequest ||
                 id > 599)
             {
-                httpCode = (int)HttpStatusCode.InternalServerError;
+                httpCode = StatusCodes.Status500InternalServerError;
             }
 
             string title = _resources.ErrorTitle;
@@ -93,32 +94,32 @@ namespace MartinCostello.LondonTravel.Site.Controllers
 
             switch (httpCode)
             {
-                case (int)HttpStatusCode.BadRequest:
+                case StatusCodes.Status400BadRequest:
                     title = _resources.ErrorTitle400;
                     subtitle = _resources.ErrorSubtitle400;
                     message = _resources.ErrorMessage400;
                     break;
 
-                case (int)HttpStatusCode.Forbidden:
+                case StatusCodes.Status403Forbidden:
                     title = _resources.ErrorTitle403;
                     subtitle = _resources.ErrorSubtitle403;
                     message = _resources.ErrorMessage403;
                     break;
 
-                case (int)HttpStatusCode.MethodNotAllowed:
+                case StatusCodes.Status405MethodNotAllowed:
                     title = _resources.ErrorTitle405;
                     subtitle = _resources.ErrorSubtitle405;
                     message = _resources.ErrorMessage405;
                     break;
 
-                case (int)HttpStatusCode.NotFound:
+                case StatusCodes.Status404NotFound:
                     title = _resources.ErrorTitle404;
                     subtitle = _resources.ErrorSubtitle404;
                     message = _resources.ErrorMessage404;
                     isUserError = true;
                     break;
 
-                case (int)HttpStatusCode.RequestTimeout:
+                case StatusCodes.Status408RequestTimeout:
                     title = _resources.ErrorTitle408;
                     subtitle = _resources.ErrorSubtitle408;
                     message = _resources.ErrorMessage408;

--- a/src/LondonTravel.Site/Controllers/RegisterController.cs
+++ b/src/LondonTravel.Site/Controllers/RegisterController.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Controllers
+{
+    using System;
+    using System.Threading.Tasks;
+    using MartinCostello.LondonTravel.Site.Models;
+    using MartinCostello.LondonTravel.Site.Services;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+
+    public class RegisterController : Controller
+    {
+        private readonly IAccountService _service;
+        private readonly ILogger<RegisterController> _logger;
+
+        public RegisterController(IAccountService service, ILogger<RegisterController> logger)
+        {
+            _service = service;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Gets the result for the <c>/account/register/</c> action.
+        /// </summary>
+        /// <returns>
+        /// The result for the <c>/account/register/</c> action.
+        /// </returns>
+        [AllowAnonymous]
+        [HttpGet]
+        [Route("account/register", Name = SiteRoutes.Register)]
+        public async Task<IActionResult> Index()
+        {
+            if (User.Identity.IsAuthenticated)
+            {
+                return RedirectToRoute(SiteRoutes.Home);
+            }
+
+            long count = await GetRegisteredUsersCountAsync();
+
+            var model = new RegisterViewModel()
+            {
+                RegisteredUsers = count,
+            };
+
+            return View(model);
+        }
+
+        private async Task<long> GetRegisteredUsersCountAsync()
+        {
+            try
+            {
+                long count = await _service.GetUserCountAsync(useCache: true);
+
+                // Round down to the nearest thousand.
+                // Deduct one for "over X,000 users".
+                return ((count - 1) / 1000) * 1000;
+            }
+            catch (Exception)
+            {
+                // Over 5,000 users as of 01/01/2018
+                return 5000;
+            }
+        }
+    }
+}

--- a/src/LondonTravel.Site/LondonTravel.Site.csproj
+++ b/src/LondonTravel.Site/LondonTravel.Site.csproj
@@ -37,14 +37,14 @@
     <PackageReference Include="Microsoft.Azure.KeyVault.WebKey" Version="2.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NodaTime" Version="2.2.3" />
-    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="Serilog" Version="2.6.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.4.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.5.0" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.UDP" Version="4.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="1.1.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="8.6.0" />
+    <PackageReference Include="WindowsAzure.Storage" Version="8.7.0" />
   </ItemGroup>
   <Target Name="BundleAssets" BeforeTargets="PrepareForPublish">
     <Exec Command="npm install --loglevel=error" Condition=" '$(InstallWebPackages)' == 'true' " />

--- a/src/LondonTravel.Site/Models/RegisterViewModel.cs
+++ b/src/LondonTravel.Site/Models/RegisterViewModel.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Models
+{
+    /// <summary>
+    /// A class representing the view model for the registration page.
+    /// </summary>
+    public sealed class RegisterViewModel
+    {
+        /// <summary>
+        /// Gets or sets the approximate number of registered users.
+        /// </summary>
+        public long RegisteredUsers { get; set; }
+    }
+}

--- a/src/LondonTravel.Site/Services/AccountService.cs
+++ b/src/LondonTravel.Site/Services/AccountService.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Services
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using MartinCostello.LondonTravel.Site.Identity;
+    using MartinCostello.LondonTravel.Site.Services.Data;
+    using Microsoft.Extensions.Caching.Memory;
+    using Microsoft.Extensions.Logging;
+
+    public class AccountService : IAccountService
+    {
+        /// <summary>
+        /// The <see cref="IDocumentClient"/> to use. This field is read-only.
+        /// </summary>
+        private readonly IDocumentClient _client;
+
+        /// <summary>
+        /// The <see cref="IMemoryCache"/> to use. This field is read-only.
+        /// </summary>
+        private readonly IMemoryCache _cache;
+
+        /// <summary>
+        /// The <see cref="ILogger"/> to use. This field is read-only.
+        /// </summary>
+        private readonly ILogger<AccountService> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AccountService"/> class.
+        /// </summary>
+        /// <param name="client">The <see cref="IDocumentClient"/> to use.</param>
+        /// <param name="cache">The <see cref="IMemoryCache"/> to use.</param>
+        /// <param name="logger">The <see cref="ILogger"/> to use.</param>
+        public AccountService(IDocumentClient client, IMemoryCache cache, ILogger<AccountService> logger)
+        {
+            _client = client;
+            _cache = cache;
+            _logger = logger;
+        }
+
+        public async Task<LondonTravelUser> GetUserByAccessTokenAsync(string accessToken, CancellationToken cancellationToken)
+        {
+            LondonTravelUser user = null;
+
+            if (!string.IsNullOrEmpty(accessToken))
+            {
+                try
+                {
+                    user = (await _client.GetAsync<LondonTravelUser>((p) => p.AlexaToken == accessToken, cancellationToken)).FirstOrDefault();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(default, ex, "Failed to find user by access token.");
+                    throw;
+                }
+            }
+
+            return user;
+        }
+
+        public Task<long> GetUserCountAsync(bool useCache)
+        {
+            return useCache ? GetUserCountFromCacheAsync() : GetUserCountFromDocumentStoreAsync();
+        }
+
+        private async Task<long> GetUserCountFromCacheAsync()
+        {
+            const string CacheKey = "DocumentStore.Count";
+
+            if (!_cache.TryGetValue(CacheKey, out long count))
+            {
+                count = await GetUserCountFromDocumentStoreAsync();
+
+                _cache.Set(CacheKey, count, TimeSpan.FromHours(12));
+            }
+
+            return count;
+        }
+
+        private Task<long> GetUserCountFromDocumentStoreAsync()
+        {
+            return _client.GetDocumentCountAsync();
+        }
+    }
+}

--- a/src/LondonTravel.Site/Services/IAccountService.cs
+++ b/src/LondonTravel.Site/Services/IAccountService.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Services
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using MartinCostello.LondonTravel.Site.Identity;
+
+    /// <summary>
+    /// Defines operations for account management.
+    /// </summary>
+    public interface IAccountService
+    {
+        /// <summary>
+        /// Gets the user with the specified access token, if any, as an asynchronous operation.
+        /// </summary>
+        /// <param name="accessToken">The access token to find the user for.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the user
+        /// with the specified access token, if found, otherwise <see langword="null"/>.
+        /// </returns>
+        Task<LondonTravelUser> GetUserByAccessTokenAsync(string accessToken, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Gets the number of registered users as an asynchronous operation.
+        /// </summary>
+        /// <param name="useCache">Whether to use the cached value of users.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the number of registered users.
+        /// </returns>
+        Task<long> GetUserCountAsync(bool useCache);
+    }
+}

--- a/src/LondonTravel.Site/Services/Tfl/TflService.cs
+++ b/src/LondonTravel.Site/Services/Tfl/TflService.cs
@@ -129,10 +129,7 @@ namespace MartinCostello.LondonTravel.Site.Services.Tfl
                         response.Headers.CacheControl != null &&
                         response.Headers.CacheControl.MaxAge.HasValue)
                     {
-                        var options = new MemoryCacheEntryOptions()
-                            .SetAbsoluteExpiration(response.Headers.CacheControl.MaxAge.Value);
-
-                        _cache.Set(cacheKey, result, options);
+                        _cache.Set(cacheKey, result, absoluteExpirationRelativeToNow: response.Headers.CacheControl.MaxAge.Value);
                     }
                 }
             }

--- a/src/LondonTravel.Site/SiteResources.cs
+++ b/src/LondonTravel.Site/SiteResources.cs
@@ -327,6 +327,8 @@ namespace MartinCostello.LondonTravel.Site
 
         public LocalizedHtmlString OtherLinesTitle(string classes, int count) => _htmlLocalizer[nameof(OtherLinesTitle), classes, count];
 
+        public string RegisterParagraph4(long count) => _localizer[nameof(RegisterParagraph4), count];
+
         public string RemoveAccountButtonAltText(string provider) => _localizer[nameof(RemoveAccountButtonAltText), provider];
 
         public string SignInButtonText(string diplayName) => _localizer[nameof(SignInButtonText), diplayName];

--- a/src/LondonTravel.Site/SiteResources.resx
+++ b/src/LondonTravel.Site/SiteResources.resx
@@ -576,4 +576,7 @@
   <data name="ApiDocumentationMetaTitle" xml:space="preserve">
     <value>API Documentation</value>
   </data>
+  <data name="RegisterParagraph4" xml:space="preserve">
+    <value>More than {0:N0} users have registered an account.</value>
+  </data>
 </root>

--- a/src/LondonTravel.Site/StartupBase.cs
+++ b/src/LondonTravel.Site/StartupBase.cs
@@ -9,6 +9,7 @@ namespace MartinCostello.LondonTravel.Site
     using Autofac.Extensions.DependencyInjection;
     using Extensions;
     using Identity;
+    using MartinCostello.LondonTravel.Site.Services;
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.AspNetCore.Authentication.Cookies;
@@ -206,6 +207,7 @@ namespace MartinCostello.LondonTravel.Site
 
             services.AddScoped<SiteResources>();
             services.AddHttpClient();
+            services.AddTransient<IAccountService, AccountService>();
             services.AddTransient<ITflService, TflService>();
 
             services

--- a/src/LondonTravel.Site/Views/Register/Index.cshtml
+++ b/src/LondonTravel.Site/Views/Register/Index.cshtml
@@ -39,6 +39,9 @@
                     </li>
                 </ul>
             </p>
+            <p>
+                @SR.RegisterParagraph4(Model.RegisteredUsers)
+            </p>
         </section>
     </div>
 </div>

--- a/src/LondonTravel.Site/Views/Register/Index.cshtml
+++ b/src/LondonTravel.Site/Views/Register/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@{
+@model RegisterViewModel
+@{
     ViewBag.MetaDescription = SR.RegisterMetaDescription;
     ViewBag.Title = SR.RegisterTitle;
 }

--- a/tests/LondonTravel.Site.Tests/Controllers/AlexaControllerTests.cs
+++ b/tests/LondonTravel.Site.Tests/Controllers/AlexaControllerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.LondonTravel.Site.Controllers
@@ -278,12 +278,12 @@ namespace MartinCostello.LondonTravel.Site.Controllers
         }
 
         /// <summary>
-        /// Creates an instance of <see cref="ApiController"/> using mock dependencies.
+        /// Creates an instance of <see cref="AlexaController"/> using mock dependencies.
         /// </summary>
         /// <param name="userManager">An optional instance of <see cref="UserManager{TUser}"/>.</param>
         /// <param name="options">An optional instance of <see cref="SiteOptions"/>.</param>
         /// <returns>
-        /// The created instance of <see cref=""/>.
+        /// The created instance of <see cref="AlexaController"/>.
         /// </returns>
         private static AlexaController CreateTarget(
             UserManager<LondonTravelUser> userManager = null,

--- a/tests/LondonTravel.Site.Tests/Controllers/RegisterControllerTests.cs
+++ b/tests/LondonTravel.Site.Tests/Controllers/RegisterControllerTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+namespace MartinCostello.LondonTravel.Site.Controllers
+{
+    using System;
+    using System.Security.Claims;
+    using System.Threading.Tasks;
+    using MartinCostello.LondonTravel.Site.Models;
+    using MartinCostello.LondonTravel.Site.Services;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Controllers;
+    using Microsoft.AspNetCore.Routing;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Shouldly;
+    using Xunit;
+
+    /// <summary>
+    /// A class containing tests for the <see cref="RegisterController"/> class. This class cannot be inherited.
+    /// </summary>
+    public static class RegisterControllerTests
+    {
+        [Theory]
+        [InlineData(5000, 4000)]
+        [InlineData(5001, 5000)]
+        [InlineData(5999, 5000)]
+        [InlineData(6000, 5000)]
+        [InlineData(6001, 6000)]
+        public static async Task Register_Rounds_User_Count_Correctly(int userCount, long expected)
+        {
+            // Arrange
+            var mock = new Mock<IAccountService>();
+
+            mock.Setup((p) => p.GetUserCountAsync(true))
+                .ReturnsAsync(userCount);
+
+            using (RegisterController target = CreateTarget(service: mock.Object))
+            {
+                // Act
+                var actual = await target.Index();
+
+                // Assert
+                actual.ShouldNotBeNull();
+
+                var view = actual.ShouldBeOfType<ViewResult>();
+                var model = view.Model.ShouldBeOfType<RegisterViewModel>();
+
+                model.ShouldNotBeNull();
+                model.RegisteredUsers.ShouldBe(expected);
+            }
+        }
+
+        [Fact]
+        public static async Task Register_Returns_Correct_Fallback_Value()
+        {
+            // Arrange
+            var mock = new Mock<IAccountService>();
+
+            mock.Setup((p) => p.GetUserCountAsync(true))
+                .ThrowsAsync(new InvalidOperationException());
+
+            using (RegisterController target = CreateTarget(service: mock.Object))
+            {
+                // Act
+                var actual = await target.Index();
+
+                // Assert
+                actual.ShouldNotBeNull();
+
+                var view = actual.ShouldBeOfType<ViewResult>();
+                var model = view.Model.ShouldBeOfType<RegisterViewModel>();
+
+                model.ShouldNotBeNull();
+                model.RegisteredUsers.ShouldBe(5000);
+            }
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="RegisterController"/> using mock dependencies.
+        /// </summary>
+        /// <param name="service">An optional instance of <see cref="IAccountService"/>.</param>
+        /// <returns>
+        /// The created instance of <see cref="RegisterController"/>.
+        /// </returns>
+        private static RegisterController CreateTarget(IAccountService service = null)
+        {
+            var httpContext = new Mock<HttpContext>();
+
+            httpContext
+                .Setup((p) => p.User)
+                .Returns(new ClaimsPrincipal(new ClaimsIdentity()));
+
+            var actionContext = new ActionContext()
+            {
+                ActionDescriptor = new ControllerActionDescriptor(),
+                HttpContext = httpContext.Object,
+                RouteData = new RouteData(),
+            };
+
+            var controllerContext = new ControllerContext(actionContext);
+
+            return new RegisterController(service, Mock.Of<ILogger<RegisterController>>())
+            {
+                ControllerContext = controllerContext,
+            };
+        }
+    }
+}

--- a/tests/LondonTravel.Site.Tests/Integration/ResourceTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/ResourceTests.cs
@@ -71,10 +71,10 @@ namespace MartinCostello.LondonTravel.Site.Integration
             using (var response = await Fixture.Client.GetAsync(requestUri))
             {
                 // Assert
-                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                Assert.Equal(contentType, response.Content.Headers.ContentType?.MediaType);
-                Assert.NotNull(response.Content.Headers.ContentLength);
-                Assert.NotEqual(0, response.Content.Headers.ContentLength);
+                response.StatusCode.ShouldBe(HttpStatusCode.OK, $"Failed to get {requestUri}. {await response.Content.ReadAsStringAsync()}");
+                response.Content.Headers.ContentType?.MediaType.ShouldBe(contentType);
+                response.Content.Headers.ContentLength.ShouldNotBeNull();
+                response.Content.Headers.ContentLength.ShouldNotBe(0);
             }
         }
 
@@ -88,8 +88,8 @@ namespace MartinCostello.LondonTravel.Site.Integration
             using (var response = await Fixture.Client.GetAsync(requestUri))
             {
                 // Assert
-                Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
-                Assert.Equal(location, response.Headers.Location?.OriginalString);
+                response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+                response.Headers.Location?.OriginalString.ShouldBe(location);
             }
         }
 
@@ -103,8 +103,8 @@ namespace MartinCostello.LondonTravel.Site.Integration
             using (var response = await Fixture.Client.GetAsync(requestUri))
             {
                 // Assert
-                Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
-                Assert.Equal($"/account/sign-in/?ReturnUrl={Uri.EscapeDataString(requestUri)}", response.Headers.Location?.PathAndQuery);
+                response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+                response.Headers.Location?.PathAndQuery.ShouldBe($"/account/sign-in/?ReturnUrl={Uri.EscapeDataString(requestUri)}");
             }
         }
 
@@ -120,7 +120,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
                 string json = await response.Content.ReadAsStringAsync();
                 JObject manifest = JObject.Parse(json);
 
-                Assert.Equal("London Travel", (string)manifest["name"]);
+                ((string)manifest["name"]).ShouldBe("London Travel");
             }
         }
 
@@ -150,7 +150,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
                 // Assert
                 foreach (string expected in expectedHeaders)
                 {
-                    Assert.True(response.Headers.Contains(expected), $"The '{expected}' response header was not found.");
+                    response.Headers.Contains(expected).ShouldBeTrue($"The '{expected}' response header was not found.");
                 }
             }
         }
@@ -188,8 +188,8 @@ namespace MartinCostello.LondonTravel.Site.Integration
             using (var response = await Fixture.Client.GetAsync(requestUri))
             {
                 // Assert
-                Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
-                Assert.Equal("www.youtube.com", response.Headers.Location?.Host);
+                response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+                response.Headers.Location?.Host.ShouldBe("www.youtube.com");
             }
 
             // Arrange
@@ -199,8 +199,8 @@ namespace MartinCostello.LondonTravel.Site.Integration
                 using (var response = await Fixture.Client.SendAsync(message))
                 {
                     // Assert
-                    Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
-                    Assert.Equal("www.youtube.com", response.Headers.Location?.Host);
+                    response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+                    response.Headers.Location?.Host.ShouldBe("www.youtube.com");
                 }
             }
 
@@ -211,8 +211,8 @@ namespace MartinCostello.LondonTravel.Site.Integration
                 using (var response = await Fixture.Client.PostAsync(requestUri, content))
                 {
                     // Assert
-                    Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
-                    Assert.Equal("www.youtube.com", response.Headers.Location?.Host);
+                    response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+                    response.Headers.Location?.Host.ShouldBe("www.youtube.com");
                 }
             }
         }

--- a/tests/LondonTravel.Site.Tests/Integration/SiteMapTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/SiteMapTests.cs
@@ -60,7 +60,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
 
                 using (var response = await Fixture.Client.GetAsync(uri.PathAndQuery))
                 {
-                    response.StatusCode.ShouldBe(HttpStatusCode.OK, $"Failed to get {uri.PathAndQuery}.");
+                    response.StatusCode.ShouldBe(HttpStatusCode.OK, $"Failed to get {uri.PathAndQuery}. {await response.Content.ReadAsStringAsync()}");
                     response.Content.Headers.ContentType?.MediaType.ShouldBe("text/html");
                     response.Content.Headers.ContentLength.ShouldNotBeNull();
                     response.Content.Headers.ContentLength.Value.ShouldBeGreaterThan(0);

--- a/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
+++ b/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
@@ -16,9 +16,9 @@
     <PackageReference Include="JustEat.HttpClientInterception" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Moq" Version="4.7.145" />
+    <PackageReference Include="Moq" Version="4.8.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="ReportGenerator" Version="3.0.2" />
+    <PackageReference Include="ReportGenerator" Version="3.1.1" />
     <PackageReference Include="Shouldly" Version="2.8.3" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
  * Show the approximate number of users on the registration page.
  * Simplify usage of `IMemoryCache`.
  * Use the `StatusCodes` constants instead of casting from `HttpStatusCode`.
  * Fix generation of assembly metadata in VSTS (#163).
  * Fix some incorrect XML documentation.
  * Use Shouldly more in tests instead of xunit's `Assert` class.