### PR TITLE
Reduce log noise from authentication

### DIFF
--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -12,7 +12,8 @@
       "Default": "Debug",
       "Override": {
         "System": "Error",
-        "Microsoft": "Error"
+        "Microsoft": "Error",
+        "MartinCostello.LondonTravel.Site.Identity.Amazon.AmazonHandler": "Error"
       }
     }
   },


### PR DESCRIPTION
Reduce log noise from authentication caused by the [custom type used for Amazon authentication](https://github.com/martincostello/alexa-london-travel-site/blob/35887642f7e854ee3fea319aef45b276024617a5/src/LondonTravel.Site/Identity/Amazon/AmazonHandler.cs#L20), which meant that the [filter for Microsoft loggers](https://github.com/martincostello/alexa-london-travel-site/blob/35887642f7e854ee3fea319aef45b276024617a5/src/LondonTravel.Site/appsettings.json#L15) to only log at Error was bypassed as the logger [that is created](https://github.com/aspnet/Security/blob/81bc3ece605758cd45508f6874424afd06cc2108/src/Microsoft.AspNetCore.Authentication/AuthenticationHandler.cs#L63) is given a name that logs at a higher level instead.