### PR TITLE
Try and fix files in .well-known causing a 404

### DIFF
--- a/src/LondonTravel.Site/web.config
+++ b/src/LondonTravel.Site/web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <system.webServer>
     <handlers>
@@ -19,6 +19,9 @@
         <remove name="X-Powered-By" />
       </customHeaders>
     </httpProtocol>
+    <staticContent>
+      <mimeMap fileExtension="." mimeType="application/octet-stream" />
+    </staticContent>
     <urlCompression doDynamicCompression="true" doStaticCompression="true" />
     <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" disableStartUpErrorPage="true" />
     <security>


### PR DESCRIPTION
Try and fix files in the `.well-known` folder causing an HTTP 404 in Azure.

This is definitely something that has changed recently, as this used to work. Maybe part of the Windows Server 2016 upgrade?