### PR TITLE
Fix .well-known folder not being published

### DIFF
--- a/src/LondonTravel.Site/LondonTravel.Site.csproj
+++ b/src/LondonTravel.Site/LondonTravel.Site.csproj
@@ -56,6 +56,7 @@
   <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths">
     <ItemGroup>
       <Content Include="wwwroot/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Content)" />
+      <Content Include="wwwroot/.well-known/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/LondonTravel.Site/web.config
+++ b/src/LondonTravel.Site/web.config
@@ -19,9 +19,6 @@
         <remove name="X-Powered-By" />
       </customHeaders>
     </httpProtocol>
-    <staticContent>
-      <mimeMap fileExtension="." mimeType="application/octet-stream" />
-    </staticContent>
     <urlCompression doDynamicCompression="true" doStaticCompression="true" />
     <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" disableStartUpErrorPage="true" />
     <security>


### PR DESCRIPTION
  * Fix the `.well-known` folder not being included by dotnet publish by updating MSBuild targets (dotnet/cli#8483).
  * Remove previous attempt at fix. (#170)