### PR TITLE
Fix CSP error from Pingdom RUM script

### DIFF
--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -87,6 +87,7 @@
       "child-src": [],
       "connect-src": [
         "dc.services.visualstudio.com",
+        "rum-collector-2.pingdom.net",
         "www.google-analytics.com"
       ],
       "default-src": [


### PR DESCRIPTION
Fix CSP error caused by a new collection domain for Pingdom Real User Monitoring script.