### PR TITLE
Update JustEat.HttpClientInterception

### DIFF
--- a/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
+++ b/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\..\src\LondonTravel.Site\LondonTravel.Site.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JustEat.HttpClientInterception" Version="1.2.0" />
+    <PackageReference Include="JustEat.HttpClientInterception" Version="1.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Moq" Version="4.8.2" />


### PR DESCRIPTION
Update JustEat.HttpClientInterception to `1.2.1` to pick up a [bug fix](https://github.com/justeat/httpclient-interception/releases/tag/v1.2.1).