### PR TITLE
Collect Cosmos DB request units in Application Insights

### DIFF
--- a/src/LondonTravel.Site/StartupBase.cs
+++ b/src/LondonTravel.Site/StartupBase.cs
@@ -197,6 +197,7 @@ namespace MartinCostello.LondonTravel.Site
             services.AddSingleton<IDocumentClient, DocumentClientWrapper>();
             services.AddSingleton<ISiteTelemetry, SiteTelemetry>();
             services.AddSingleton<ITelemetryInitializer, SiteTelemetryInitializer>();
+            services.AddSingleton<ITelemetryModule, SiteTelemetryModule>();
             services.AddSingleton<ITflServiceFactory, TflServiceFactory>();
             services.AddSingleton((_) => ConfigureJsonFormatter(new JsonSerializerSettings()));
 

--- a/src/LondonTravel.Site/Telemetry/ApplicationInsightsUrlFilter.cs
+++ b/src/LondonTravel.Site/Telemetry/ApplicationInsightsUrlFilter.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Telemetry
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    /// <summary>
+    /// A class representing a filter for HTTP requests to Application Insights. This class cannot be inherited.
+    /// </summary>
+    /// <remarks>
+    /// Based on <c>https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/db53106c5d85546a2508ecb9dcd6bf1106fb29fa/Src/DependencyCollector/Shared/Implementation/ApplicationInsightsUrlFilter.cs</c>.
+    /// </remarks>
+    internal sealed class ApplicationInsightsUrlFilter
+    {
+        private const string QuickPulseServiceEndpoint = "https://rt.services.visualstudio.com/QuickPulseService.svc";
+        private const string TelemetryServiceEndpoint = "https://dc.services.visualstudio.com/v2/track";
+
+        private readonly TelemetryConfiguration _configuration;
+        private readonly Uri _telemetryServiceEndpointUri = new Uri(TelemetryServiceEndpoint);
+
+        private KeyValuePair<string, string> _cachedEndpointLeftPart;
+
+        internal ApplicationInsightsUrlFilter(TelemetryConfiguration configuration)
+        {
+            _configuration = configuration;
+            _cachedEndpointLeftPart = GetEndpointLeftPart();
+        }
+
+        private string EndpointLeftPart
+        {
+            get
+            {
+                string currentEndpointAddressValue = null;
+
+                if (_configuration != null)
+                {
+                    string endpoint = _configuration.TelemetryChannel.EndpointAddress;
+
+                    if (!string.IsNullOrEmpty(endpoint))
+                    {
+                        currentEndpointAddressValue = endpoint;
+                    }
+                }
+
+                if (_cachedEndpointLeftPart.Key != currentEndpointAddressValue)
+                {
+                    _cachedEndpointLeftPart = GetEndpointLeftPart(currentEndpointAddressValue);
+                }
+
+                return _cachedEndpointLeftPart.Value;
+            }
+        }
+
+        internal bool IsApplicationInsightsUrl(Uri uri)
+        {
+            if (SdkInternalOperationsMonitor.IsEntered())
+            {
+                return true;
+            }
+
+            bool result = false;
+            string url = uri?.ToString();
+
+            if (!string.IsNullOrEmpty(url))
+            {
+                result = url.StartsWith(TelemetryServiceEndpoint, StringComparison.OrdinalIgnoreCase) ||
+                         url.StartsWith(QuickPulseServiceEndpoint, StringComparison.OrdinalIgnoreCase);
+
+                if (!result)
+                {
+                    string endpointUrl = EndpointLeftPart;
+
+                    if (!string.IsNullOrEmpty(endpointUrl))
+                    {
+                        result = url.StartsWith(endpointUrl, StringComparison.OrdinalIgnoreCase);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private KeyValuePair<string, string> GetEndpointLeftPart(string currentEndpointAddressValue = null)
+        {
+            Uri uri = currentEndpointAddressValue != null ? new Uri(currentEndpointAddressValue) : _telemetryServiceEndpointUri;
+            string endpointLeftPart = uri.Scheme + "://" + uri.Authority;
+
+            return new KeyValuePair<string, string>(currentEndpointAddressValue, endpointLeftPart);
+        }
+    }
+}

--- a/src/LondonTravel.Site/Telemetry/HttpRequestActivityEnricher.cs
+++ b/src/LondonTravel.Site/Telemetry/HttpRequestActivityEnricher.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Telemetry
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.Extensions.DiagnosticAdapter;
+
+    /// <summary>
+    /// A class that enriches the current activity with HTTP response headers. This class cannot be inherited.
+    /// </summary>
+    internal sealed class HttpRequestActivityEnricher : IObserver<DiagnosticListener>, IDisposable
+    {
+        /// <summary>
+        /// The URL filter to use for Application Insights. This field is read-only.
+        /// </summary>
+        private readonly ApplicationInsightsUrlFilter _filter;
+
+        /// <summary>
+        /// The active diagnostic listener subscriptions. This field is read-only.
+        /// </summary>
+        private readonly IList<IDisposable> _subscriptions;
+
+        public HttpRequestActivityEnricher(TelemetryConfiguration configuration)
+        {
+            _filter = new ApplicationInsightsUrlFilter(configuration);
+            _subscriptions = new List<IDisposable>();
+        }
+
+        /// <summary>
+        /// Subscribes the enricher to all diagnostic listeners.
+        /// </summary>
+        public void Subscribe()
+        {
+            _subscriptions.Add(DiagnosticListener.AllListeners.Subscribe(this));
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            foreach (IDisposable subscription in _subscriptions)
+            {
+                subscription.Dispose();
+            }
+        }
+
+        [DiagnosticName("System.Net.Http.HttpRequestOut.Stop")]
+        public void OnHttpRequestOutStop(HttpRequestMessage request, HttpResponseMessage response, TaskStatus requestTaskStatus)
+        {
+            if (request != null && response != null && !_filter.IsApplicationInsightsUrl(request.RequestUri))
+            {
+                var activity = Activity.Current;
+
+                if (activity != null)
+                {
+                    if (response.Headers.TryGetValues("x-ms-activity-id", out var values))
+                    {
+                        activity.AddTag("Activity Id", string.Join(", ", values));
+                    }
+
+                    if (response.Headers.TryGetValues("x-ms-request-charge", out values))
+                    {
+                        activity.AddTag("Request Charge", string.Join(", ", values));
+                    }
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        void IObserver<DiagnosticListener>.OnCompleted()
+        {
+            // Not used
+        }
+
+        /// <inheritdoc />
+        void IObserver<DiagnosticListener>.OnError(Exception error)
+        {
+            // Not used
+        }
+
+        /// <inheritdoc />
+        void IObserver<DiagnosticListener>.OnNext(DiagnosticListener value)
+        {
+            if (value.Name == "HttpHandlerDiagnosticListener")
+            {
+                _subscriptions.Add(value.SubscribeWithAdapter(this));
+            }
+        }
+    }
+}

--- a/src/LondonTravel.Site/Telemetry/SiteTelemetryInitializer.cs
+++ b/src/LondonTravel.Site/Telemetry/SiteTelemetryInitializer.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.LondonTravel.Site.Telemetry
 {
     using Extensions;
     using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
@@ -47,6 +48,19 @@ namespace MartinCostello.LondonTravel.Site.Telemetry
                 if (_contextAccessor.HttpContext.User?.Identity?.IsAuthenticated == true)
                 {
                     telemetry.Context.User.AuthenticatedUserId = _contextAccessor.HttpContext.User.GetUserId();
+                }
+            }
+
+            if (telemetry is DependencyTelemetry dependency)
+            {
+                var activity = System.Diagnostics.Activity.Current;
+
+                if (activity != null)
+                {
+                    foreach (var item in activity.Tags)
+                    {
+                        dependency.Properties[item.Key] = item.Value;
+                    }
                 }
             }
         }

--- a/src/LondonTravel.Site/Telemetry/SiteTelemetryModule.cs
+++ b/src/LondonTravel.Site/Telemetry/SiteTelemetryModule.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Telemetry
+{
+    using System;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    /// <summary>
+    /// A class representing an Application Insights module for custom telemetry. This class cannot be inherited.
+    /// </summary>
+    internal sealed class SiteTelemetryModule : ITelemetryModule, IDisposable
+    {
+        /// <summary>
+        /// The object used for synchronization. This field is read-only.
+        /// </summary>
+        private readonly object _syncRoot = new object();
+
+        /// <summary>
+        /// The activity enricher in use for HTTP calls.
+        /// </summary>
+        private HttpRequestActivityEnricher _enricher;
+
+        /// <summary>
+        /// Whether the instance has been disposed.
+        /// </summary>
+        private bool _disposed;
+
+        /// <summary>
+        /// Whether the instance has been initialized.
+        /// </summary>
+        private bool _initialized;
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="SiteTelemetryModule"/> class.
+        /// </summary>
+        ~SiteTelemetryModule()
+        {
+            Dispose(false);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc />
+        public void Initialize(TelemetryConfiguration configuration)
+        {
+            if (!_initialized)
+            {
+                lock (_syncRoot)
+                {
+                    if (!_initialized)
+                    {
+                        _enricher = new HttpRequestActivityEnricher(configuration);
+                        _enricher.Subscribe();
+
+                        _initialized = true;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <param name="disposing">
+        /// <see langword="true" /> to release both managed and unmanaged resources;
+        /// <see langword="false" /> to release only unmanaged resources.
+        /// </param>
+        private void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _enricher?.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Enable tracking of the Activity Id and Request Charge for Cosmos DB requests in Application Insights.

Based on [this blog post](http://geeklearning.io/application-insights-extensibility-tricks-worth-knowing-1-2/) as well as an [old branch](https://github.com/martincostello/alexa-london-travel-site/tree/Collect-DocumentDb-Headers) that tried to implement this previously.