### PR TITLE
Simplify request localisation

### DIFF
--- a/src/LondonTravel.Site/Startup.cs
+++ b/src/LondonTravel.Site/Startup.cs
@@ -4,7 +4,6 @@
 namespace MartinCostello.LondonTravel.Site
 {
     using System;
-    using System.Globalization;
     using Extensions;
     using MartinCostello.LondonTravel.Site.Services;
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
@@ -16,7 +15,6 @@ namespace MartinCostello.LondonTravel.Site
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.HttpOverrides;
-    using Microsoft.AspNetCore.Localization;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Razor;
     using Microsoft.AspNetCore.StaticFiles;
@@ -73,19 +71,7 @@ namespace MartinCostello.LondonTravel.Site
         {
             app.UseCustomHttpHeaders(HostingEnvironment, Configuration, options);
 
-            var supportedCultures = new[]
-            {
-                new CultureInfo("en-GB"),
-                new CultureInfo("en-US"),
-            };
-
-            app.UseRequestLocalization(
-                new RequestLocalizationOptions()
-                {
-                    DefaultRequestCulture = new RequestCulture("en-GB"),
-                    SupportedCultures = supportedCultures,
-                    SupportedUICultures = supportedCultures,
-                });
+            app.UseRequestLocalization("en-GB", "en-US");
 
             if (HostingEnvironment.IsDevelopment())
             {


### PR DESCRIPTION
Use new 2.1 overload of `UseRequestLocalization()` that simplifies things.