### PR TITLE
Use extension method to get attributes

### DIFF
--- a/src/LondonTravel.Site/Swagger/ExampleFilter.cs
+++ b/src/LondonTravel.Site/Swagger/ExampleFilter.cs
@@ -34,8 +34,8 @@ namespace MartinCostello.LondonTravel.Site.Swagger
         {
             if (operation != null && context?.ApiDescription != null && context.SchemaRegistry != null)
             {
-                var responseAttributes = context.MethodInfo.GetCustomAttributes(typeof(SwaggerResponseExampleAttribute), true)
-                    .OfType<SwaggerResponseExampleAttribute>()
+                var responseAttributes = context.MethodInfo
+                    .GetCustomAttributes<SwaggerResponseExampleAttribute>(true)
                     .ToList();
 
                 foreach (var attribute in responseAttributes)


### PR DESCRIPTION
Use extension method to get the Swagger example attributes to make the code a bit cleaner.