### PR TITLE
Fix login provider names not being displayed

### DIFF
--- a/src/LondonTravel.Site/Controllers/ManageController.cs
+++ b/src/LondonTravel.Site/Controllers/ManageController.cs
@@ -78,6 +78,14 @@ namespace MartinCostello.LondonTravel.Site.Controllers
                 .ThenBy((p) => p.Name)
                 .ToList();
 
+            foreach (var login in userLogins)
+            {
+                if (string.IsNullOrWhiteSpace(login.ProviderDisplayName))
+                {
+                    login.ProviderDisplayName = login.LoginProvider;
+                }
+            }
+
             var model = new ManageViewModel()
             {
                 CurrentLogins = userLogins,


### PR DESCRIPTION
If a login provider does not have a display name, fall back to the login provider's name.