### PR TITLE
Trim Feature-Policy from Swagger UI

### DIFF
--- a/src/LondonTravel.Site/assets/scripts/ts/Swagger.ts
+++ b/src/LondonTravel.Site/assets/scripts/ts/Swagger.ts
@@ -41,6 +41,7 @@ window.onload = () => {
                 // Delete overly-verbose headers from the UI
                 delete response.headers["content-security-policy"];
                 delete response.headers["content-security-policy-report-only"];
+                delete response.headers["feataure-policy"];
             }
         });
 

--- a/tests/LondonTravel.Site.Tests/Integration/ResourceTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/ResourceTests.cs
@@ -150,6 +150,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
             {
                 "content-security-policy",
                 "content-security-policy-report-only",
+                "feature-policy",
                 "Referrer-Policy",
                 "X-Content-Type-Options",
                 "X-CSP-Nonce",


### PR DESCRIPTION
  * Do not display the `Feature-Policy` HTTP response header in Swagger UI.
  * Update unit test to check that the Feature-Policy HTTP response header is returned.
