### PR TITLE
Add Managed Service Identity Opt-out

### DIFF
--- a/src/LondonTravel.Site/Extensions/IConfigurationBuilderExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/IConfigurationBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
+    using System;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Azure.KeyVault;
     using Microsoft.Azure.Services.AppAuthentication;
@@ -36,6 +37,7 @@ namespace MartinCostello.LondonTravel.Site.Extensions
 
             // Can Managed Service Identity be used instead of direct Key Vault integration?
             bool canUseMsi =
+                !string.Equals(config["WEBSITE_DISABLE_MSI"], bool.TrueString, StringComparison.OrdinalIgnoreCase) &&
                 !string.IsNullOrEmpty(config["MSI_ENDPOINT"]) &&
                 !string.IsNullOrEmpty(config["MSI_SECRET"]);
 


### PR DESCRIPTION
Add an opt-out for Managed Service Identity (MSI) for if somehow it's not configured correctly. Azure App Service should blank out `MSI_ENDPOINT` and `MSI_SECRET` if it's `true`, but going for a belt-and-braces approach.

This is because the first deployment of #201 broke it because the access wasn't set up correctly. That was fixed by just setting `WEBSITE_DISABLE_MSI=true`, but would rather also check it in code rather than rely on platform behaviour.