### PR TITLE
Use shorter .NET Core SDK download links

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -44,7 +44,7 @@ if ($installDotNetSdk -eq $true) {
             mkdir $env:DOTNET_INSTALL_DIR | Out-Null
         }
         $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.ps1"
-        Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/v$dotnetVersion/scripts/obtain/dotnet-install.ps1" -OutFile $installScript -UseBasicParsing
+        Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile $installScript -UseBasicParsing
         & $installScript -Version "$dotnetVersion" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath
     }
 

--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ export PATH="$DOTNET_INSTALL_DIR:$PATH"
 dotnet_version=$(dotnet --version)
 
 if [ "$dotnet_version" != "$CLI_VERSION" ]; then
-    curl -sSL https://raw.githubusercontent.com/dotnet/cli/v$CLI_VERSION/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
+    curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
 fi
 
 dotnet publish ./src/LondonTravel.Site/LondonTravel.Site.csproj --output $artifacts/publish --configuration $configuration || exit 1

--- a/src/LondonTravel.Site/package-lock.json
+++ b/src/LondonTravel.Site/package-lock.json
@@ -688,9 +688,9 @@
       }
     },
     "bootstrap": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
-      "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E=",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.3.tgz",
+      "integrity": "sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w==",
       "dev": true
     },
     "brace-expansion": {
@@ -5791,6 +5791,12 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
           "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+          "dev": true
+        },
+        "bootstrap": {
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+          "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E=",
           "dev": true
         },
         "braces": {

--- a/src/LondonTravel.Site/package.json
+++ b/src/LondonTravel.Site/package.json
@@ -7,6 +7,7 @@
     "@types/google.analytics": "0.0.39",
     "@types/jasmine": "2.8.8",
     "@types/jquery": "3.3.5",
+    "bootstrap": "4.1.3",
     "cryptiles": "4.1.2",
     "del": "3.0.0",
     "gulp": "3.9.1",


### PR DESCRIPTION
Use convenience download URL for the .NET Core SDK installation script that I found [here](https://github.com/Microsoft/azure-pipelines-image-generation/blob/def0bc672d17fcefbe0ab9f5f75ab5b9e950d052/images/win/scripts/Installers/Install-DotnetSDK.ps1#L17)

Also update an npm package to resolve a GitHub "vulnerability" alert.