### PR TITLE
Disable Application Insights in tests

### DIFF
--- a/src/LondonTravel.Site/Program.cs
+++ b/src/LondonTravel.Site/Program.cs
@@ -38,7 +38,6 @@ namespace MartinCostello.LondonTravel.Site
         {
             return WebHost.CreateDefaultBuilder(args)
                 .UseKestrel((p) => p.AddServerHeader = false)
-                .UseApplicationInsights()
                 .UseAzureAppServices()
                 .UseStartup<Startup>()
                 .ConfigureAppConfiguration((context, builder) => builder.ConfigureApplication(context))

--- a/src/LondonTravel.Site/Telemetry/SiteTelemetryModule.cs
+++ b/src/LondonTravel.Site/Telemetry/SiteTelemetryModule.cs
@@ -55,8 +55,11 @@ namespace MartinCostello.LondonTravel.Site.Telemetry
                 {
                     if (!_initialized)
                     {
-                        _enricher = new HttpRequestActivityEnricher(configuration);
-                        _enricher.Subscribe();
+                        if (!configuration.DisableTelemetry)
+                        {
+                            _enricher = new HttpRequestActivityEnricher(configuration);
+                            _enricher.Subscribe();
+                        }
 
                         _initialized = true;
                     }

--- a/tests/LondonTravel.Site.Tests/Integration/BrowserTest.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/BrowserTest.cs
@@ -301,9 +301,15 @@ namespace MartinCostello.LondonTravel.Site.Integration
                     Screenshot screenshot = camera.GetScreenshot();
 
                     string directory = Path.GetDirectoryName(typeof(BrowserTest).Assembly.Location);
-                    string fileName = $"{testName}_{DateTimeOffset.UtcNow:YYYY-MM-dd-HH-mm-ss}.png";
+                    directory = Path.Combine(directory, "screenshots");
 
-                    fileName = Path.Combine(directory, "screenshots", fileName);
+                    string fileName = $"{testName}_{DateTimeOffset.UtcNow:yyyy-MM-dd-HH-mm-ss}.png";
+                    fileName = Path.Combine(directory, fileName);
+
+                    if (!Directory.Exists(directory))
+                    {
+                        Directory.CreateDirectory(directory);
+                    }
 
                     screenshot.SaveAsFile(fileName);
                 }

--- a/tests/LondonTravel.Site.Tests/Integration/HttpServerCollection.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/HttpServerCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.LondonTravel.Site.Integration
@@ -8,7 +8,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
     /// <summary>
     /// A class representing the collection fixture for an HTTP server. This class cannot be inherited.
     /// </summary>
-    [CollectionDefinition(Name)]
+    [CollectionDefinition(Name, DisableParallelization = true)]
     public sealed class HttpServerCollection : ICollectionFixture<HttpServerFixture>
     {
         /// <summary>

--- a/tests/LondonTravel.Site.Tests/Integration/HttpServerCollection.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/HttpServerCollection.cs
@@ -8,7 +8,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
     /// <summary>
     /// A class representing the collection fixture for an HTTP server. This class cannot be inherited.
     /// </summary>
-    [CollectionDefinition(Name, DisableParallelization = true)]
+    [CollectionDefinition(Name, DisableParallelization = true)] // Causes issues with ApplicationInsights if not disabled
     public sealed class HttpServerCollection : ICollectionFixture<HttpServerFixture>
     {
         /// <summary>

--- a/tests/LondonTravel.Site.Tests/Integration/HttpServerFixture.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/HttpServerFixture.cs
@@ -10,6 +10,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
     using System.Security.Cryptography.X509Certificates;
     using MartinCostello.Logging.XUnit;
     using Microsoft.ApplicationInsights.DependencyCollector;
+    using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.TestHost;
     using Microsoft.Extensions.DependencyInjection;
@@ -159,6 +160,8 @@ namespace MartinCostello.LondonTravel.Site.Integration
                     module.SetComponentCorrelationHttpHeaders = false;
                     module.IncludeDiagnosticSourceActivities.Clear();
                 });
+
+            services.Configure<TelemetryConfiguration>((p) => p.DisableTelemetry = true);
         }
     }
 }

--- a/tests/LondonTravel.Site.Tests/Integration/HttpServerFixture.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/HttpServerFixture.cs
@@ -9,8 +9,6 @@ namespace MartinCostello.LondonTravel.Site.Integration
     using System.Net.Sockets;
     using System.Security.Cryptography.X509Certificates;
     using MartinCostello.Logging.XUnit;
-    using Microsoft.ApplicationInsights.DependencyCollector;
-    using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.TestHost;
     using Microsoft.Extensions.DependencyInjection;
@@ -152,16 +150,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
                 (_) => new RemoteAuthorizationEventsFilter(ServerAddress));
 
             // Disable dependency tracking to work around https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1006
-            services.ConfigureTelemetryModule<DependencyTrackingTelemetryModule>(
-                (module, _) =>
-                {
-                    module.DisableDiagnosticSourceInstrumentation = true;
-                    module.DisableRuntimeInstrumentation = true;
-                    module.SetComponentCorrelationHttpHeaders = false;
-                    module.IncludeDiagnosticSourceActivities.Clear();
-                });
-
-            services.Configure<TelemetryConfiguration>((p) => p.DisableTelemetry = true);
+            services.DisableApplicationInsights();
         }
     }
 }

--- a/tests/LondonTravel.Site.Tests/Integration/IServiceCollectionExtensions.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/IServiceCollectionExtensions.cs
@@ -6,7 +6,6 @@ namespace MartinCostello.LondonTravel.Site.Integration
     using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.DependencyInjection.Extensions;
 
     internal static class IServiceCollectionExtensions
     {
@@ -22,9 +21,6 @@ namespace MartinCostello.LondonTravel.Site.Integration
                     module.SetComponentCorrelationHttpHeaders = false;
                     module.IncludeDiagnosticSourceActivities.Clear();
                 });
-
-            services.RemoveAll<ITelemetryInitializer>();
-            services.RemoveAll<ITelemetryModule>();
         }
     }
 }

--- a/tests/LondonTravel.Site.Tests/Integration/IServiceCollectionExtensions.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/IServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
     using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
 
     internal static class IServiceCollectionExtensions
     {
@@ -21,6 +22,9 @@ namespace MartinCostello.LondonTravel.Site.Integration
                     module.SetComponentCorrelationHttpHeaders = false;
                     module.IncludeDiagnosticSourceActivities.Clear();
                 });
+
+            services.RemoveAll<ITelemetryInitializer>();
+            services.RemoveAll<ITelemetryModule>();
         }
     }
 }

--- a/tests/LondonTravel.Site.Tests/Integration/IServiceCollectionExtensions.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/IServiceCollectionExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Integration
+{
+    using Microsoft.ApplicationInsights.DependencyCollector;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.Extensions.DependencyInjection;
+
+    internal static class IServiceCollectionExtensions
+    {
+        internal static void DisableApplicationInsights(this IServiceCollection services)
+        {
+            // Disable dependency tracking to work around https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1006
+            services.Configure<TelemetryConfiguration>((p) => p.DisableTelemetry = true);
+            services.ConfigureTelemetryModule<DependencyTrackingTelemetryModule>(
+                (module, _) =>
+                {
+                    module.DisableDiagnosticSourceInstrumentation = true;
+                    module.DisableRuntimeInstrumentation = true;
+                    module.SetComponentCorrelationHttpHeaders = false;
+                    module.IncludeDiagnosticSourceActivities.Clear();
+                });
+        }
+    }
+}

--- a/tests/LondonTravel.Site.Tests/Integration/TestServerCollection.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/TestServerCollection.cs
@@ -8,7 +8,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
     /// <summary>
     /// A class representing the collection fixture for a test server. This class cannot be inherited.
     /// </summary>
-    [CollectionDefinition(Name, DisableParallelization = true)]
+    [CollectionDefinition(Name, DisableParallelization = true)] // Causes issues with ApplicationInsights if not disabled
     public sealed class TestServerCollection : ICollectionFixture<TestServerFixture>
     {
         /// <summary>

--- a/tests/LondonTravel.Site.Tests/Integration/TestServerCollection.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/TestServerCollection.cs
@@ -8,7 +8,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
     /// <summary>
     /// A class representing the collection fixture for a test server. This class cannot be inherited.
     /// </summary>
-    [CollectionDefinition(Name)]
+    [CollectionDefinition(Name, DisableParallelization = true)]
     public sealed class TestServerCollection : ICollectionFixture<TestServerFixture>
     {
         /// <summary>

--- a/tests/LondonTravel.Site.Tests/Integration/TestServerCollection.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/TestServerCollection.cs
@@ -8,7 +8,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
     /// <summary>
     /// A class representing the collection fixture for a test server. This class cannot be inherited.
     /// </summary>
-    [CollectionDefinition(Name, DisableParallelization = true)] // Causes issues with ApplicationInsights if not disabled
+    [CollectionDefinition(Name)]
     public sealed class TestServerCollection : ICollectionFixture<TestServerFixture>
     {
         /// <summary>

--- a/tests/LondonTravel.Site.Tests/Integration/TestServerFixture.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/TestServerFixture.cs
@@ -69,6 +69,10 @@ namespace MartinCostello.LondonTravel.Site.Integration
                     services.AddSingleton<IDocumentCollectionInitializer>((p) => p.GetRequiredService<InMemoryDocumentStore>());
                 });
 
+            // Disable dependency tracking to work around https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1006
+            builder.ConfigureServices(
+                (services) => services.DisableApplicationInsights());
+
             builder.ConfigureAppConfiguration(ConfigureTests)
                    .ConfigureLogging((loggingBuilder) => loggingBuilder.ClearProviders().AddXUnit());
         }

--- a/tests/LondonTravel.Site.Tests/xunit.runner.json
+++ b/tests/LondonTravel.Site.Tests/xunit.runner.json
@@ -1,4 +1,6 @@
 {
+  "maxParallelThreads": 1,
   "methodDisplay": "method",
-  "methodDisplayOptions": "replaceUnderscoreWithSpace"
+  "methodDisplayOptions": "replaceUnderscoreWithSpace",
+  "parallelizeTestCollections": false
 }


### PR DESCRIPTION
Disable Application Insights in the UI tests to work around issue related to Microsoft/ApplicationInsights-dotnet-server#1006,
