### PR TITLE
Update dependencies

### DIFF
--- a/tests/LondonTravel.Site.Tests/Integration/Builders/AccessTokensInterceptionBuilder.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/Builders/AccessTokensInterceptionBuilder.cs
@@ -6,7 +6,6 @@ namespace MartinCostello.LondonTravel.Site.Integration.Builders
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-    using System.Linq;
     using JustEat.HttpClientInterception;
 
     /// <summary>
@@ -222,9 +221,7 @@ namespace MartinCostello.LondonTravel.Site.Integration.Builders
 
             return new HttpRequestInterceptionBuilder()
                 .Requests().ForPost().ForUrl(url)
-                .Responds()
-                .WithContent(string.Join("&", form.Select((p) => $"{p.Key}={p.Value}")))
-                .WithMediaType("application/x-www-form-urlencoded");
+                .Responds().WithFormContent(form);
         }
     }
 }

--- a/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
+++ b/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
@@ -15,11 +15,11 @@
     <ProjectReference Include="..\..\src\LondonTravel.Site\LondonTravel.Site.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JustEat.HttpClientInterception" Version="1.2.1" />
+    <PackageReference Include="JustEat.HttpClientInterception" Version="1.2.2" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="Selenium.Support" Version="3.14.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.14.0" />


### PR DESCRIPTION
  * Update `JustEat.HttpClientInterception` to version `1.2.2` to use URL-encoded form content method.
  * Update `Microsoft.NET.Test.Sdk` to `15.9.0`.
