### PR TITLE
Enable Reporting API

### DIFF
--- a/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
@@ -117,6 +117,9 @@ namespace MartinCostello.LondonTravel.Site.Middleware
                         context.Response.Headers.Add("Expect-CT", _expectCTValue);
                     }
 
+                    context.Response.Headers.Add("Report-To", @"{""group"":""default"",""max_age"":31536000,""endpoints"":[{""url"":""https://martincostello.report-uri.com/a/d/g""}],""include_subdomains"":false}");
+                    context.Response.Headers.Add("NEL", @"{""report_to"":""default"",""max_age"":31536000,""include_subdomains"":false}");
+
                     context.Response.Headers.Add("X-Datacenter", _config.AzureDatacenter());
 
 #if DEBUG

--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -148,11 +148,11 @@
       "Skill": "https://www.amazon.co.uk/dp/B01NB0T86R",
       "Status": "http://status.martincostello.com/2575630",
       "Reports": {
-        "ContentSecurityPolicy": "https://martincostello.report-uri.io/r/default/csp/enforce",
-        "ContentSecurityPolicyReportOnly": "https://martincostello.report-uri.io/r/default/csp/reportOnly",
-        "ExpectCTEnforce": "https://martincostello.report-uri.io/r/default/ct/enforce",
-        "ExpectCTReportOnly": "https://martincostello.report-uri.io/r/default/ct/reportOnly",
-        "ExpectStaple": "https://martincostello.report-uri.io/r/default/staple/reportOnly"
+        "ContentSecurityPolicy": "https://martincostello.report-uri.com/r/d/csp/enforce",
+        "ContentSecurityPolicyReportOnly": "https://martincostello.report-uri.com/r/d/csp/reportOnly",
+        "ExpectCTEnforce": "https://martincostello.report-uri.com/r/d/ct/enforce",
+        "ExpectCTReportOnly": "https://martincostello.report-uri.com/r/d/ct/reportOnly",
+        "ExpectStaple": "https://martincostello.report-uri.com/r/d/staple/reportOnly"
       }
     },
     "Metadata": {

--- a/tests/LondonTravel.Site.Tests/Integration/ResourceTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/ResourceTests.cs
@@ -7,6 +7,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
+    using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using Shouldly;
     using Xunit;
@@ -153,7 +154,9 @@ namespace MartinCostello.LondonTravel.Site.Integration
                 "content-security-policy",
                 "content-security-policy-report-only",
                 "feature-policy",
+                "NEL",
                 "Referrer-Policy",
+                "Report-To",
                 "X-Content-Type-Options",
                 "X-CSP-Nonce",
                 "X-Datacenter",
@@ -175,6 +178,25 @@ namespace MartinCostello.LondonTravel.Site.Integration
                     {
                         response.Headers.Contains(expected).ShouldBeTrue($"The '{expected}' response header was not found.");
                     }
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("NEL")]
+        [InlineData("Report-To")]
+        public async Task Response_Headers_Is_Valid_Json(string name)
+        {
+            // Act
+            using (var client = Fixture.CreateClient())
+            {
+                using (var response = await client.GetAsync("/"))
+                {
+                    // Assert
+                    response.Headers.Contains(name).ShouldBeTrue($"The '{name}' response header was not found.");
+
+                    string json = string.Join(string.Empty, response.Headers.GetValues(name));
+                    JObject.Parse(json).HasValues.ShouldBeTrue();
                 }
             }
         }


### PR DESCRIPTION
  * Use the new `Report-To` and `NEL` HTTP response headers for the Chrome M70 Reporting API.
  * Update Report URI reporting endpoints.

Resolves #234.
