### PR TITLE
Stop using preview pools in Azure Pipelines

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -19,9 +19,9 @@ phases:
       ${{ if ne(parameters.queueName, '') }}:
         name: ${{ parameters.queueName }}
       ${{ if and(eq(parameters.queueName, ''), eq(parameters.agentOS, 'Linux')) }}:
-        name: Hosted Linux Preview
+        name: Hosted Ubuntu 1604
       ${{ if and(eq(parameters.queueName, ''), eq(parameters.agentOS, 'macOS')) }}:
-        name: Hosted macOS Preview
+        name: Hosted macOS
       ${{ if and(eq(parameters.queueName, ''), eq(parameters.agentOS, 'Windows')) }}:
         name: Hosted VS2017
     variables:

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -33,14 +33,20 @@ phases:
       - ${{ parameters.beforeBuild }}
       - ${{ if eq(parameters.agentOS, 'Linux') }}:
         - script: |
-            apt-get update
-            apt-get install -y --no-install-recommends gettext libcurl4-openssl-dev libicu-dev libssl-dev libunwind8
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends gettext libcurl4-openssl-dev libicu-dev libssl-dev libunwind8
           name: InstallDotNetCoreDeps
           displayName: Install .NET Core pre-requisites
-      - script: |
-          npm install -g npm
-        name: UpdateNpm
-        displayName: Update to latest npm
+      - ${{ if eq(parameters.agentOS, 'Linux') }}:
+        - script: |
+            sudo npm install -g npm
+          name: UpdateNpm
+          displayName: Update to latest npm
+      - ${{ if ne(parameters.agentOS, 'Linux') }}:
+        - script: |
+            npm install -g npm
+          name: UpdateNpm
+          displayName: Update to latest npm
       - ${{ if eq(parameters.agentOS, 'macOS') }}:
         - script: |
             npm install -g gulp@3.9.1


### PR DESCRIPTION
Stop using the preview pools for Linux and macOS to fix warning about the Linux pool being deprecated.