### PR TITLE
Update DocumentDB client and inject HTTP handler

### DIFF
--- a/src/LondonTravel.Site/InternalsVisibleTo.cs
+++ b/src/LondonTravel.Site/InternalsVisibleTo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("LondonTravel.Site.Tests")]

--- a/src/LondonTravel.Site/LondonTravel.Site.csproj
+++ b/src/LondonTravel.Site/LondonTravel.Site.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.3" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.KeyVault.WebKey" Version="3.0.2" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />

--- a/src/LondonTravel.Site/Startup.cs
+++ b/src/LondonTravel.Site/Startup.cs
@@ -170,7 +170,7 @@ namespace MartinCostello.LondonTravel.Site
             services.AddSingleton<ITelemetryInitializer, SiteTelemetryInitializer>();
             services.AddSingleton<ITflServiceFactory, TflServiceFactory>();
             services.AddSingleton((_) => ConfigureJsonFormatter(new JsonSerializerSettings()));
-            services.AddSingleton((p) => DocumentHelpers.CreateClient(p.GetRequiredService<UserStoreOptions>()));
+            services.AddSingleton(DocumentHelpers.CreateClient);
 
             services.TryAddSingleton<IDocumentService, DocumentService>();
             services.TryAddSingleton<IDocumentCollectionInitializer, DocumentCollectionInitializer>();

--- a/tests/LondonTravel.Site.Tests/Services/Data/DocumentHelpersTests.cs
+++ b/tests/LondonTravel.Site.Tests/Services/Data/DocumentHelpersTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Services.Data
+{
+    using System;
+    using System.Net.Http;
+    using MartinCostello.LondonTravel.Site.Options;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Extensions.DependencyInjection;
+    using Moq;
+    using Shouldly;
+    using Xunit;
+
+    public static class DocumentHelpersTests
+    {
+        [Fact]
+        public static void CreateClient_Throws_If_ServiceProvider_Is_Null()
+        {
+            // Arrange
+            IServiceProvider serviceProvider = null;
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("serviceProvider", () => DocumentHelpers.CreateClient(serviceProvider));
+        }
+
+        [Fact]
+        public static void CreateClient_Throws_If_Options_Is_Null()
+        {
+            // Arrange
+            UserStoreOptions options = null;
+            HttpMessageHandler handler = Mock.Of<HttpMessageHandler>();
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("options", () => DocumentHelpers.CreateClient(options, handler));
+        }
+
+        [Fact]
+        public static void CreateClient_Throws_If_Handler_Is_Null()
+        {
+            // Arrange
+            UserStoreOptions options = new UserStoreOptions();
+            HttpMessageHandler handler = null;
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>("handler", () => DocumentHelpers.CreateClient(options, handler));
+        }
+
+        [Fact]
+        public static void CreateClient_Throws_If_Options_Has_No_Service_Endpoint()
+        {
+            // Arrange
+            var handler = Mock.Of<HttpMessageHandler>();
+
+            var options = new UserStoreOptions()
+            {
+                ServiceUri = null,
+                AccessKey = "bpfYUKmfV0arChaIPI3hU3+bn3w=",
+                DatabaseName = "my-database",
+                CollectionName = "my-collection",
+            };
+
+            // Act and Assert
+            Assert.Throws<ArgumentException>("options", () => DocumentHelpers.CreateClient(options, handler));
+        }
+
+        [Fact]
+        public static void CreateClient_Throws_If_Options_Has_Relative_Service_Endpoint()
+        {
+            // Arrange
+            var handler = Mock.Of<HttpMessageHandler>();
+
+            var options = new UserStoreOptions()
+            {
+                ServiceUri = new Uri("/", UriKind.Relative),
+                AccessKey = "bpfYUKmfV0arChaIPI3hU3+bn3w=",
+                DatabaseName = "my-database",
+                CollectionName = "my-collection",
+            };
+
+            // Act and Assert
+            Assert.Throws<ArgumentException>("options", () => DocumentHelpers.CreateClient(options, handler));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public static void CreateClient_Throws_If_Options_Has_No_Access_Key(string accessKey)
+        {
+            // Arrange
+            var handler = Mock.Of<HttpMessageHandler>();
+
+            var options = new UserStoreOptions()
+            {
+                ServiceUri = new Uri("https://cosmosdb.azure.local"),
+                AccessKey = accessKey,
+                DatabaseName = "my-database",
+                CollectionName = "my-collection",
+            };
+
+            // Act and Assert
+            Assert.Throws<ArgumentException>("options", () => DocumentHelpers.CreateClient(options, handler));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public static void CreateClient_Throws_If_Options_Has_No_Database_Name(string databaseName)
+        {
+            // Arrange
+            var handler = Mock.Of<HttpMessageHandler>();
+
+            var options = new UserStoreOptions()
+            {
+                ServiceUri = new Uri("https://cosmosdb.azure.local"),
+                AccessKey = "bpfYUKmfV0arChaIPI3hU3+bn3w=",
+                DatabaseName = databaseName,
+                CollectionName = "my-collection",
+            };
+
+            // Act and Assert
+            Assert.Throws<ArgumentException>("options", () => DocumentHelpers.CreateClient(options, handler));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public static void CreateClient_Throws_If_Options_Has_No_Collection_Name(string collectionName)
+        {
+            // Arrange
+            var handler = Mock.Of<HttpMessageHandler>();
+
+            var options = new UserStoreOptions()
+            {
+                ServiceUri = new Uri("https://cosmosdb.azure.local"),
+                AccessKey = "bpfYUKmfV0arChaIPI3hU3+bn3w=",
+                DatabaseName = "my-database",
+                CollectionName = collectionName,
+            };
+
+            // Act and Assert
+            Assert.Throws<ArgumentException>("options", () => DocumentHelpers.CreateClient(options, handler));
+        }
+
+        [Fact]
+        public static void CreateClient_Creates_Client_From_Service_Provider_With_Locations()
+        {
+            // Arrange
+            var options = new UserStoreOptions()
+            {
+                ServiceUri = new Uri("https://cosmosdb.azure.local"),
+                AccessKey = "bpfYUKmfV0arChaIPI3hU3+bn3w=",
+                DatabaseName = "my-database",
+                CollectionName = "my-collection",
+                CurrentLocation = "UK South",
+                PreferredLocations = new[] { "UK South", "East US" },
+            };
+
+            var services = new ServiceCollection()
+                .AddSingleton(options)
+                .AddHttpClient();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            // Act
+            IDocumentClient actual = DocumentHelpers.CreateClient(serviceProvider);
+
+            // Assert
+            actual.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public static void CreateClient_Creates_Client_From_Service_Provider_With_No_Locations()
+        {
+            // Arrange
+            var options = new UserStoreOptions()
+            {
+                ServiceUri = new Uri("https://cosmosdb.azure.local"),
+                AccessKey = "bpfYUKmfV0arChaIPI3hU3+bn3w=",
+                DatabaseName = "my-database",
+                CollectionName = "my-collection",
+            };
+
+            var services = new ServiceCollection()
+                .AddSingleton(options)
+                .AddHttpClient();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            // Act
+            IDocumentClient actual = DocumentHelpers.CreateClient(serviceProvider);
+
+            // Assert
+            actual.ShouldNotBeNull();
+        }
+    }
+}


### PR DESCRIPTION
  1. Update to the latest version of Microsoft.Azure.DocumentDB.Core.
  1. Use `IHttpMessageHandlerFactory` to inject an `HttpMessageHandler` instance into the `DocumentClient` instance.

See Azure/azure-cosmos-dotnet-v2#245 and aspnet/HttpClientFactory#118.