### PR TITLE
Use Xenial in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: required
-dist: trusty
+dist: xenial
+dotnet: 2.2
+language: csharp
+mono: none
 
 os:
   - linux


### PR DESCRIPTION
  * Update Travis CI to use `xenial` instead of `trusty`.
  * Try out built-in C# support.

See https://travis-ci.community/t/dotnet-core-2-2/1216/9.