### PR TITLE
Refactor Startup dependency injection

### DIFF
--- a/tests/LondonTravel.Site.Tests/Integration/AccountTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/AccountTests.cs
@@ -60,7 +60,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
             IUserStore<LondonTravelUser> GetUserStore(IServiceProvider serviceProvider)
                 => serviceProvider.GetRequiredService<IUserStore<LondonTravelUser>>();
 
-            using (var scope = Fixture.Server.Host.Services.CreateScope())
+            using (var scope = Fixture.Services.CreateScope())
             {
                 using (IUserStore<LondonTravelUser> store = GetUserStore(scope.ServiceProvider))
                 {
@@ -142,7 +142,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
             }
 
             // Arrange
-            using (var scope = Fixture.Server.Host.Services.CreateScope())
+            using (var scope = Fixture.Services.CreateScope())
             {
                 using (IUserStore<LondonTravelUser> store = GetUserStore(scope.ServiceProvider))
                 {

--- a/tests/LondonTravel.Site.Tests/Integration/HttpServerFixture.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/HttpServerFixture.cs
@@ -9,7 +9,6 @@ namespace MartinCostello.LondonTravel.Site.Integration
     using System.Net.Sockets;
     using System.Security.Cryptography.X509Certificates;
     using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.TestHost;
     using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>
@@ -28,15 +27,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
         {
             ClientOptions.BaseAddress = FindFreeServerAddress();
 
-            string applicationBasePath = AppContext.BaseDirectory;
-
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TF_BUILD")))
-            {
-                applicationBasePath = Environment.GetEnvironmentVariable("BUILD_SOURCESDIRECTORY");
-            }
-
             var builder = CreateWebHostBuilder()
-                .UseSolutionRelativeContentRoot("src/LondonTravel.Site", applicationBasePath: applicationBasePath)
                 .UseUrls(ClientOptions.BaseAddress.ToString())
                 .UseKestrel(
                     (p) => p.ConfigureHttpsDefaults(

--- a/tests/LondonTravel.Site.Tests/Integration/HttpServerFixture.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/HttpServerFixture.cs
@@ -8,11 +8,9 @@ namespace MartinCostello.LondonTravel.Site.Integration
     using System.Net.Http;
     using System.Net.Sockets;
     using System.Security.Cryptography.X509Certificates;
-    using MartinCostello.Logging.XUnit;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.TestHost;
     using Microsoft.Extensions.DependencyInjection;
-    using Xunit.Abstractions;
 
     /// <summary>
     /// A test fixture representing an HTTP server hosting the application. This class cannot be inherited.
@@ -55,6 +53,9 @@ namespace MartinCostello.LondonTravel.Site.Integration
         /// </summary>
         public Uri ServerAddress => ClientOptions.BaseAddress;
 
+        /// <inheritdoc />
+        public override IServiceProvider Services => _webHost?.Services;
+
         /// <summary>
         /// Creates an <see cref="HttpClient"/> to communicate with the application.
         /// </summary>
@@ -84,14 +85,6 @@ namespace MartinCostello.LondonTravel.Site.Integration
 
             return client;
         }
-
-        /// <inheritdoc />
-        public override void ClearOutputHelper()
-            => _webHost.Services.GetRequiredService<ITestOutputHelperAccessor>().OutputHelper = null;
-
-        /// <inheritdoc />
-        public override void SetOutputHelper(ITestOutputHelper value)
-            => _webHost.Services.GetRequiredService<ITestOutputHelperAccessor>().OutputHelper = value;
 
         /// <inheritdoc />
         protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/tests/LondonTravel.Site.Tests/Integration/TestServerFixture.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/TestServerFixture.cs
@@ -30,10 +30,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
             ClientOptions.AllowAutoRedirect = false;
             ClientOptions.BaseAddress = new Uri("https://localhost");
 
-            // HACK Force HTTP server startup
-            using (CreateDefaultClient())
-            {
-            }
+            EnsureStarted();
         }
 
         /// <summary>
@@ -42,17 +39,30 @@ namespace MartinCostello.LondonTravel.Site.Integration
         public HttpClientInterceptorOptions Interceptor { get; } = new HttpClientInterceptorOptions() { ThrowOnMissingRegistration = true };
 
         /// <summary>
+        /// Gets the <see cref="IServiceProvider"/> in use.
+        /// </summary>
+        public virtual IServiceProvider Services => Server?.Host?.Services;
+
+        /// <summary>
         /// Clears the current <see cref="ITestOutputHelper"/>.
         /// </summary>
         public virtual void ClearOutputHelper()
-            => Server.Host.Services.GetRequiredService<ITestOutputHelperAccessor>().OutputHelper = null;
+        {
+            if (Services != null)
+            {
+                Services.GetRequiredService<ITestOutputHelperAccessor>().OutputHelper = null;
+            }
+        }
 
         /// <summary>
         /// Sets the <see cref="ITestOutputHelper"/> to use.
         /// </summary>
         /// <param name="value">The <see cref="ITestOutputHelper"/> to use.</param>
         public virtual void SetOutputHelper(ITestOutputHelper value)
-            => Server.Host.Services.GetRequiredService<ITestOutputHelperAccessor>().OutputHelper = value;
+        {
+            EnsureStarted();
+            Services.GetRequiredService<ITestOutputHelperAccessor>().OutputHelper = value;
+        }
 
         /// <inheritdoc />
         protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -89,6 +99,14 @@ namespace MartinCostello.LondonTravel.Site.Integration
             builder.AddJsonFile("appsettings.json")
                    .AddJsonFile(fullPath)
                    .AddEnvironmentVariables();
+        }
+
+        private void EnsureStarted()
+        {
+            // HACK Force HTTP server startup
+            using (CreateDefaultClient())
+            {
+            }
         }
     }
 }

--- a/tests/LondonTravel.Site.Tests/Integration/TestServerFixture.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/TestServerFixture.cs
@@ -5,6 +5,8 @@ namespace MartinCostello.LondonTravel.Site.Integration
 {
     using System;
     using System.IO;
+    using System.Linq;
+    using System.Reflection;
     using JustEat.HttpClientInterception;
     using MartinCostello.Logging.XUnit;
     using MartinCostello.LondonTravel.Site.Services.Data;
@@ -84,10 +86,28 @@ namespace MartinCostello.LondonTravel.Site.Integration
                 (services) => services.DisableApplicationInsights());
 
             builder.ConfigureAppConfiguration(ConfigureTests)
-                   .ConfigureLogging((loggingBuilder) => loggingBuilder.ClearProviders().AddXUnit());
+                   .ConfigureLogging((loggingBuilder) => loggingBuilder.ClearProviders().AddXUnit())
+                   .UseContentRoot(GetApplicationContentRootPath());
         }
 
-        private static void ConfigureTests(IConfigurationBuilder builder)
+        /// <summary>
+        /// Gets the content root path to use for the application.
+        /// </summary>
+        /// <returns>
+        /// The content root path to use for the application.
+        /// </returns>
+        protected string GetApplicationContentRootPath()
+        {
+            var attribute = GetTestAssemblies()
+                .SelectMany((p) => p.GetCustomAttributes<WebApplicationFactoryContentRootAttribute>())
+                .Where((p) => string.Equals(p.Key, "LondonTravel.Site", StringComparison.OrdinalIgnoreCase))
+                .OrderBy((p) => p.Priority)
+                .First();
+
+            return attribute.ContentRootPath;
+        }
+
+        private void ConfigureTests(IConfigurationBuilder builder)
         {
             // Remove the application's normal configuration
             builder.Sources.Clear();

--- a/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
+++ b/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Tests for https://londontravel.martincostello.com/</Description>
     <NoWarn>$(NoWarn);CA1707;CA2234</NoWarn>
@@ -13,6 +13,12 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LondonTravel.Site\LondonTravel.Site.csproj" />
+    <WebApplicationFactoryContentRootAttribute
+      Include="LondonTravel.Site"
+      AssemblyName="LondonTravel.Site"
+      ContentRootPath="$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../../src/LondonTravel.Site'))"
+      ContentRootTest="LondonTravel.Site.csproj"
+      Priority="-1" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JustEat.HttpClientInterception" Version="1.2.2" />


### PR DESCRIPTION
  * Refactor usage of `IServiceProvider` in `Startup` to prepare for ASP.NET Core 3.0 changes for the `ConfigureServices()` method now having to return `void`.
  * Use `AddHttpContextAccessor()`.
  * Refactor `TestServerFixture` and `HttpServerFixture` to make it simpler to access `IServiceProvider`.
  * Use the `<WebApplicationFactoryContentRootAttribute>` MSBuild item.