### PR TITLE
Fix Azure Pipelines build

### DIFF
--- a/src/LondonTravel.Site/package-lock.json
+++ b/src/LondonTravel.Site/package-lock.json
@@ -7806,9 +7806,9 @@
       }
     },
     "natives": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
       "dev": true
     },
     "negotiator": {

--- a/src/LondonTravel.Site/package.json
+++ b/src/LondonTravel.Site/package.json
@@ -33,6 +33,7 @@
     "karma-typescript": "3.0.13",
     "lodash": ">=4.17.11",
     "merge-stream": "1.0.1",
+    "natives": "^1.1.6",
     "path": "0.12.7",
     "puppeteer": "1.8.0",
     "superagent": "3.8.3",


### PR DESCRIPTION
Fix the Azure DevOps Pipelines build by installing natives so that the build works with node 11.