### PR TITLE
Add [JsonProperty] back to models

### DIFF
--- a/src/LondonTravel.Site/Identity/LondonTravelLoginInfo.cs
+++ b/src/LondonTravel.Site/Identity/LondonTravelLoginInfo.cs
@@ -5,6 +5,7 @@ namespace MartinCostello.LondonTravel.Site.Identity
 {
     using System.Text.Json.Serialization;
     using Microsoft.AspNetCore.Identity;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// A class representing external login information for a user.
@@ -14,18 +15,21 @@ namespace MartinCostello.LondonTravel.Site.Identity
         /// <summary>
         /// Gets or sets the login provider.
         /// </summary>
+        [JsonProperty("loginProvider")]
         [JsonPropertyName("loginProvider")]
         public string? LoginProvider { get; set; }
 
         /// <summary>
         /// Gets or sets the provider key.
         /// </summary>
+        [JsonProperty("providerKey")]
         [JsonPropertyName("providerKey")]
         public string? ProviderKey { get; set; }
 
         /// <summary>
         /// Gets or sets the provider display name.
         /// </summary>
+        [JsonProperty("providerDisplayName")]
         [JsonPropertyName("providerDisplayName")]
         public string? ProviderDisplayName { get; set; }
 

--- a/src/LondonTravel.Site/Identity/LondonTravelRole.cs
+++ b/src/LondonTravel.Site/Identity/LondonTravelRole.cs
@@ -6,6 +6,7 @@ namespace MartinCostello.LondonTravel.Site.Identity
     using System;
     using System.Security.Claims;
     using System.Text.Json.Serialization;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// A class representing a user role.
@@ -15,30 +16,35 @@ namespace MartinCostello.LondonTravel.Site.Identity
         /// <summary>
         /// Gets or sets the role Id.
         /// </summary>
+        [JsonProperty("id")]
         [JsonPropertyName("id")]
         public string? Id { get; set; }
 
         /// <summary>
         /// Gets or sets the claim's type.
         /// </summary>
+        [JsonProperty("claimType")]
         [JsonPropertyName("claimType")]
         public string? ClaimType { get; set; }
 
         /// <summary>
         /// Gets or sets the claim's value.
         /// </summary>
+        [JsonProperty("value")]
         [JsonPropertyName("value")]
         public string? Value { get; set; }
 
         /// <summary>
         /// Gets or sets the claim's value's type.
         /// </summary>
+        [JsonProperty("valueType")]
         [JsonPropertyName("valueType")]
         public string? ValueType { get; set; }
 
         /// <summary>
         /// Gets or sets the claim's issuer.
         /// </summary>
+        [JsonProperty("issuer")]
         [JsonPropertyName("issuer")]
         public string? Issuer { get; set; }
 

--- a/src/LondonTravel.Site/Identity/LondonTravelUser.cs
+++ b/src/LondonTravel.Site/Identity/LondonTravelUser.cs
@@ -6,6 +6,7 @@ namespace MartinCostello.LondonTravel.Site.Identity
     using System;
     using System.Collections.Generic;
     using System.Text.Json.Serialization;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// A class representing a user of the application.
@@ -25,96 +26,112 @@ namespace MartinCostello.LondonTravel.Site.Identity
         /// <summary>
         /// Gets or sets the user Id.
         /// </summary>
+        [JsonProperty("id")]
         [JsonPropertyName("id")]
         public string? Id { get; set; }
 
         /// <summary>
         /// Gets or sets the ETag of the underlying document.
         /// </summary>
+        [JsonProperty("_etag")]
         [JsonPropertyName("_etag")]
         public string? ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the user's email address.
         /// </summary>
+        [JsonProperty("email")]
         [JsonPropertyName("email")]
         public string? Email { get; set; }
 
         /// <summary>
         /// Gets or sets the normalized email address.
         /// </summary>
+        [JsonProperty("emailNormalized")]
         [JsonPropertyName("emailNormalized")]
         public string? EmailNormalized { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the user's email address has been confirmed.
         /// </summary>
+        [JsonProperty("emailConfirmed")]
         [JsonPropertyName("emailConfirmed")]
         public bool EmailConfirmed { get; set; }
 
         /// <summary>
         /// Gets or sets the user's given name.
         /// </summary>
+        [JsonProperty("givenName")]
         [JsonPropertyName("givenName")]
         public string? GivenName { get; set; }
 
         /// <summary>
         /// Gets or sets the user's surname.
         /// </summary>
+        [JsonProperty("surname")]
         [JsonPropertyName("surname")]
         public string? Surname { get; set; }
 
         /// <summary>
         /// Gets or sets the user name.
         /// </summary>
+        [JsonProperty("userName")]
         [JsonPropertyName("userName")]
         public string? UserName { get; set; }
 
         /// <summary>
         /// Gets or sets the normalized user name.
         /// </summary>
+        [JsonProperty("userNameNormalized")]
         [JsonPropertyName("userNameNormalized")]
         public string? UserNameNormalized { get; set; }
 
         /// <summary>
         /// Gets or sets the user's external logins.
         /// </summary>
+        [JsonProperty("logins")]
         [JsonPropertyName("logins")]
         public IList<LondonTravelLoginInfo> Logins { get; set; }
 
         /// <summary>
         /// Gets or sets the user's role claims.
         /// </summary>
+        [JsonProperty("roleClaims")]
         [JsonPropertyName("roleClaims")]
         public IList<LondonTravelRole> RoleClaims { get; set; }
 
         /// <summary>
         /// Gets or sets the user's favorite line Ids.
         /// </summary>
+        [JsonProperty("favoriteLines")]
         [JsonPropertyName("favoriteLines")]
         public IList<string> FavoriteLines { get; set; }
 
         /// <summary>
         /// Gets or sets the user's Amazon Alexa access token.
         /// </summary>
+        [JsonProperty("alexaToken")]
         [JsonPropertyName("alexaToken")]
         public string? AlexaToken { get; set; }
 
         /// <summary>
         /// Gets or sets the user's security stamp.
         /// </summary>
+        [JsonProperty("securityStamp")]
         [JsonPropertyName("securityStamp")]
         public string? SecurityStamp { get; set; }
 
         /// <summary>
         /// Gets or sets the date and time the user was created.
         /// </summary>
+        [JsonProperty("createdAt")]
         [JsonPropertyName("createdAt")]
         public DateTime CreatedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the Unix timestamp of the user document.
         /// </summary>
+        [JsonProperty("_ts")]
         [JsonPropertyName("_ts")]
         public long Timestamp { get; set; }
     }


### PR DESCRIPTION
Add `[JsonProperty]` attributes back into the models for Cosmos DB as the SDK doesn't appear to work correctly when querying items with LINQ with a custom serializer.