### PR TITLE
Use Newtonsoft.Json with Cosmos SDK

### DIFF
--- a/src/LondonTravel.Site/Services/Data/DocumentHelpers.cs
+++ b/src/LondonTravel.Site/Services/Data/DocumentHelpers.cs
@@ -4,10 +4,8 @@
 namespace MartinCostello.LondonTravel.Site.Services.Data
 {
     using System;
-    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Options;
     using Options;
 
     /// <summary>
@@ -34,10 +32,7 @@ namespace MartinCostello.LondonTravel.Site.Services.Data
 
             var options = serviceProvider.GetRequiredService<UserStoreOptions>();
 
-            var jsonOptions = serviceProvider.GetRequiredService<IOptions<JsonOptions>>().Value;
-            var serializer = new SystemTextJsonCosmosSerializer(jsonOptions.JsonSerializerOptions);
-
-            return CreateClient(options, serializer);
+            return CreateClient(options);
         }
 
         /// <summary>

--- a/src/LondonTravel.Site/Services/Data/DocumentService.cs
+++ b/src/LondonTravel.Site/Services/Data/DocumentService.cs
@@ -156,7 +156,7 @@ namespace MartinCostello.LondonTravel.Site.Services.Data
             while (iterator.HasMoreResults)
             {
                 var items = await iterator.ReadNextAsync(cancellationToken);
-                documents.AddRange(items);
+                documents.AddRange(items.Resource);
             }
 
             _logger.LogTrace(


### PR DESCRIPTION
Serialization of query results seems to fail when using System.Text.Json with the Cosmos DB SDK, so switch back to Newtonsoft.Json.
