### PR TITLE
Remove Swashbuckle.AspNetCore Workarounds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,12 +28,6 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <NoWarn Condition=" '$(GenerateDocumentationFile)' != 'true' ">$(NoWarn);SA0001</NoWarn>
     <Nullable>enable</Nullable>
-    <!--
-      Workaround issue with Open API document generation on macOS:
-      https://github.com/aspnet/AspNetCore/issues/14232
-      https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1266#issuecomment-533896204
-    -->
-    <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/martincostello/alexa-london-travel-site</PackageProjectUrl>
     <PackageReleaseNotes>$(PackageProjectUrl)/releases</PackageReleaseNotes>

--- a/src/LondonTravel.Site/LondonTravel.Site.csproj
+++ b/src/LondonTravel.Site/LondonTravel.Site.csproj
@@ -31,7 +31,6 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.KeyVault.WebKey" Version="3.0.4" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
-    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.0.0" />
     <PackageReference Include="NodaTime" Version="2.4.7" />


### PR DESCRIPTION
Remove workarounds made redundant by Swashbuckle.AspNetCore `5.0.0-rc4` (see #428).