### PR TITLE
Remove aspnet-contrib NuGet feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <add key="dotnet-core-myget" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="aspnet-contrib" value="https://www.myget.org/F/aspnet-contrib/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Remove the need to use the MyGet feed for aspnet-contrib now that the 3.0.0 packages are in NuGet.org.