### PR TITLE
Simplify AppService dependency

### DIFF
--- a/src/LondonTravel.Site/LondonTravel.Site.csproj
+++ b/src/LondonTravel.Site/LondonTravel.Site.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="3.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.3.2" />
     <PackageReference Include="Microsoft.Azure.KeyVault.WebKey" Version="3.0.4" />

--- a/src/LondonTravel.Site/Program.cs
+++ b/src/LondonTravel.Site/Program.cs
@@ -45,7 +45,6 @@ namespace MartinCostello.LondonTravel.Site
                     (webBuilder) =>
                     {
                         webBuilder.CaptureStartupErrors(true)
-                                  .UseAzureAppServices()
                                   .UseStartup<Startup>();
                     });
         }


### PR DESCRIPTION
Use Microsoft.AspNetCore.AzureAppServices.HostingStartup to automatically register AppService logging.