### PR TITLE
Restore AppInsights snippet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
         include:

--- a/src/LondonTravel.Site/Views/Shared/_Layout.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Layout.cshtml
@@ -1,4 +1,5 @@
 @inject IConfiguration Config
+@inject Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet JavaScriptSnippet
 <!DOCTYPE html>
 <html lang="en-gb">
 <head prefix="og: http://ogp.me/ns#">
@@ -26,6 +27,9 @@
     @await RenderSectionAsync("meta", required: false)
     @await Html.PartialAsync("_StylesHead")
     @await RenderSectionAsync("stylesHead", required: false)
+    <script type="text/javascript" nonce="@Context.EnsureCspNonce()">
+        @Html.Raw(JavaScriptSnippet.ScriptBody)
+    </script>
     <script type="text/javascript" nonce="@Context.EnsureCspNonce()">
         if (self == top) {
             document.documentElement.className = document.documentElement.className.replace(/\bjs-flash\b/, '');

--- a/src/LondonTravel.Site/Views/_ViewImports.cshtml
+++ b/src/LondonTravel.Site/Views/_ViewImports.cshtml
@@ -1,4 +1,4 @@
-﻿@using System
+@using System
 @using System.Globalization
 @using Microsoft.AspNetCore.Mvc.Localization
 @using Microsoft.Extensions.Configuration
@@ -9,7 +9,6 @@
 @using MartinCostello.LondonTravel.Site.Options
 @addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"
 @addTagHelper "*, LondonTravel.Site"
-@inject Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet JavaScriptSnippet
 @inject SiteOptions Options
 @inject SiteResources SR
 @inject IViewLocalizer Localizer


### PR DESCRIPTION
  * Restore the Application Insights JavaScript snippet that was removed by #262.
  * Allow other builds to continue if one OS fails.
