### PR TITLE
Fix analyzer warnings

### DIFF
--- a/src/LondonTravel.Site/Controllers/HomeController.cs
+++ b/src/LondonTravel.Site/Controllers/HomeController.cs
@@ -147,7 +147,7 @@ namespace MartinCostello.LondonTravel.Site.Controllers
                 model.AllLines.Add(favorite);
             }
 
-            model.AllLines
+            model.AllLines = model.AllLines
                 .OrderBy((p) => p.DisplayName, StringComparer.Ordinal)
                 .ToList();
 

--- a/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
@@ -315,11 +315,11 @@ namespace MartinCostello.LondonTravel.Site.Middleware
 
                 if (origins.Count > 0)
                 {
-                    builder.Append(" ");
+                    builder.Append(' ');
                     builder.Append(string.Join(" ", origins));
                 }
 
-                builder.Append(";");
+                builder.Append(';');
             }
 
             if (!isReport && _isProduction)


### PR DESCRIPTION
Fix warnings found by using version 3.3.0 of the Roslyn analyzers (see #599).