### PR TITLE
Update Content Security Policy

### DIFF
--- a/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
@@ -251,21 +251,21 @@ namespace MartinCostello.LondonTravel.Site.Middleware
 
             var policies = new Dictionary<string, IList<string>>()
             {
-                { "default-src", new[] { Csp.Self, Csp.Data } },
-                { "script-src", scriptDirectives },
-                { "style-src", styleDirectives },
-                { "img-src", new[] { Csp.Self, Csp.Data, cdn } },
-                { "font-src", new[] { Csp.Self } },
-                { "connect-src", new[] { Csp.Self } },
-                { "media-src", new[] { Csp.None } },
-                { "object-src", new[] { Csp.None } },
-                { "child-src", new[] { Csp.Self } },
-                { "frame-ancestors", new[] { Csp.None } },
-                { "form-action", new[] { Csp.Self } },
-                { "block-all-mixed-content", Array.Empty<string>() },
-                { "base-uri", new[] { Csp.Self } },
-                { "manifest-src", new[] { Csp.Self } },
-                { "worker-src", new[] { Csp.Self } },
+                ["default-src"] = new[] { Csp.Self, Csp.Data },
+                ["script-src"] = scriptDirectives,
+                ["style-src"] = styleDirectives,
+                ["img-src"] = new[] { Csp.Self, Csp.Data, cdn },
+                ["font-src"] = new[] { Csp.Self },
+                ["connect-src"] = new[] { Csp.Self },
+                ["media-src"] = new[] { Csp.None },
+                ["object-src"] = new[] { Csp.None },
+                ["child-src"] = new[] { Csp.Self },
+                ["frame-ancestors"] = new[] { Csp.None },
+                ["form-action"] = new[] { Csp.Self },
+                ["block-all-mixed-content"] = Array.Empty<string>(),
+                ["base-uri"] = new[] { Csp.Self },
+                ["manifest-src"] = new[] { Csp.Self },
+                ["worker-src"] = new[] { Csp.Self },
             };
 
             if (allowInlineStyles)

--- a/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
@@ -311,7 +311,10 @@ namespace MartinCostello.LondonTravel.Site.Middleware
                     origins = origins.Concat(configOrigins).ToList();
                 }
 
-                origins = origins.Where((p) => !string.IsNullOrWhiteSpace(p)).ToList();
+                origins = origins
+                    .Where((p) => !string.IsNullOrWhiteSpace(p))
+                    .Distinct()
+                    .ToList();
 
                 if (origins.Count > 0)
                 {

--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -119,6 +119,7 @@
         "www.facebook.com"
       ],
       "img-src": [
+        "cdn.martincostello.com",
         "martincostello.azureedge.net",
         "stats.g.doubleclick.net",
         "www.google-analytics.com",


### PR DESCRIPTION
  * Add the primary CDN domain to the `img-src` list explicitly.
  * Do not duplicate the CSP origins in the case that the configured list is the same as one of the built-in defaults.
  * Use newer syntax to initialise dictionary.
