### PR TITLE
Use Uri instead of string

### DIFF
--- a/src/LondonTravel.Site/Controllers/AccountController.cs
+++ b/src/LondonTravel.Site/Controllers/AccountController.cs
@@ -263,7 +263,7 @@ namespace MartinCostello.LondonTravel.Site.Controllers
 
                     if (returnUri != null && IsRedirectAlexaAuthorization(returnUri.ToString()))
                     {
-                        return Redirect(returnUrl);
+                        return Redirect(returnUri.ToString());
                     }
                     else
                     {


### PR DESCRIPTION
Use the validated `Uri` added in #723 instead of the original user-specified `string`.