### PR TITLE
Remove extra img-src

### DIFF
--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -124,8 +124,7 @@
         "stats.g.doubleclick.net",
         "www.google-analytics.com",
         "www.gravatar.com",
-        "*.wp.com",
-        "www.gravatar.com.*.id.opendns.com"
+        "*.wp.com"
       ],
       "object-src": [],
       "script-src": [


### PR DESCRIPTION
Remove the extra `img-src` hostname added by #725, as Chrome considers it to be invalid.
