### PR TITLE
Use custom CDN domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Alexa London Travel Site
 
-[![London Travel](https://martincostello.azureedge.net/london-travel-108x108.png "London Travel")](https://www.amazon.co.uk/dp/B01NB0T86R)
+[![London Travel](https://cdn.martincostello.com/london-travel-108x108.png "London Travel")](https://www.amazon.co.uk/dp/B01NB0T86R)
 
 [![Build status](https://github.com/martincostello/alexa-london-travel-site/workflows/build/badge.svg?branch=main&event=push)](https://github.com/martincostello/alexa-london-travel-site/actions?query=workflow%3ABuild+branch%3Amain+event%3Apush)
 

--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -141,7 +141,7 @@
     },
     "ExternalLinks": {
       "Api": "/",
-      "Cdn": "https://martincostello.azureedge.net/",
+      "Cdn": "https://cdn.martincostello.com/",
       "Skill": "https://www.amazon.co.uk/dp/B01NB0T86R",
       "Reports": {
         "ContentSecurityPolicy": "https://martincostello.report-uri.com/r/d/csp/enforce",
@@ -165,7 +165,7 @@
       },
       "Description": "London Travel is an Amazon Alexa skill for checking the status for travel in London.",
       "Domain": "londontravel.martincostello.com",
-      "Image": "https://martincostello.azureedge.net/london-travel-108x108.png",
+      "Image": "https://cdn.martincostello.com/london-travel-108x108.png",
       "Keywords": "alexa,london travel",
       "Name": "London Travel",
       "Repository": "https://github.com/martincostello/alexa-london-travel-site",

--- a/src/LondonTravel.Site/wwwroot/bad-request.html
+++ b/src/LondonTravel.Site/wwwroot/bad-request.html
@@ -7,7 +7,7 @@
     <meta name="referrer" content="no-referrer-when-downgrade" />
     <meta name="robots" content="NOINDEX" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1, maximum-scale=1" />
-    <link rel="shortcut icon" type="image/x-icon" href="https://martincostello.azureedge.net/london-travel_favicon.ico" />
+    <link rel="shortcut icon" type="image/x-icon" href="https://cdn.martincostello.com/london-travel_favicon.ico" />
 </head>
 <body>
     <nav class="navbar navbar-default navbar-fixed-top">
@@ -15,7 +15,7 @@
             <div class="navbar-header">
                 <a class="navbar-brand" title="View the homepage" href="/">
                     <span>
-                        <img src="https://martincostello.azureedge.net/london-travel_avatar.png" alt="London Travel" title="London Travel" aria-hidden="true" />
+                        <img src="https://cdn.martincostello.com/london-travel_avatar.png" alt="London Travel" title="London Travel" aria-hidden="true" />
                         London Travel
                     </span>
                 </a>

--- a/src/LondonTravel.Site/wwwroot/browserconfig.xml
+++ b/src/LondonTravel.Site/wwwroot/browserconfig.xml
@@ -2,10 +2,10 @@
 <browserconfig>
   <msapplication>
     <tile>
-      <square70x70logo src="https://martincostello.azureedge.net/london-travel_mstile-70x70.png?v=477XzzYNy7"/>
-      <square150x150logo src="https://martincostello.azureedge.net/london-travel_mstile-150x150.png?v=477XzzYNy7"/>
-      <square310x310logo src="https://martincostello.azureedge.net/london-travel_mstile-310x310.png?v=477XzzYNy7"/>
-      <wide310x150logo src="https://martincostello.azureedge.net/london-travel_mstile-310x150.png?v=477XzzYNy7"/>
+      <square70x70logo src="https://cdn.martincostello.com/london-travel_mstile-70x70.png?v=477XzzYNy7"/>
+      <square150x150logo src="https://cdn.martincostello.com/london-travel_mstile-150x150.png?v=477XzzYNy7"/>
+      <square310x310logo src="https://cdn.martincostello.com/london-travel_mstile-310x310.png?v=477XzzYNy7"/>
+      <wide310x150logo src="https://cdn.martincostello.com/london-travel_mstile-310x150.png?v=477XzzYNy7"/>
       <TileColor>#2c3e50</TileColor>
     </tile>
   </msapplication>

--- a/src/LondonTravel.Site/wwwroot/error.html
+++ b/src/LondonTravel.Site/wwwroot/error.html
@@ -7,7 +7,7 @@
     <meta name="referrer" content="no-referrer-when-downgrade" />
     <meta name="robots" content="NOINDEX" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1, maximum-scale=1" />
-    <link rel="shortcut icon" type="image/x-icon" href="https://martincostello.azureedge.net/london-travel_favicon.ico" />
+    <link rel="shortcut icon" type="image/x-icon" href="https://cdn.martincostello.com/london-travel_favicon.ico" />
 </head>
 <body>
     <nav class="navbar navbar-default navbar-fixed-top">
@@ -15,7 +15,7 @@
             <div class="navbar-header">
                 <a class="navbar-brand" title="View the homepage" href="/">
                     <span>
-                        <img src="https://martincostello.azureedge.net/london-travel_avatar.png" alt="London Travel" title="London Travel" aria-hidden="true" />
+                        <img src="https://cdn.martincostello.com/london-travel_avatar.png" alt="London Travel" title="London Travel" aria-hidden="true" />
                         London Travel
                     </span>
                 </a>

--- a/src/LondonTravel.Site/wwwroot/manifest.webmanifest
+++ b/src/LondonTravel.Site/wwwroot/manifest.webmanifest
@@ -10,42 +10,42 @@
   "dir": "ltr",
   "icons": [
     {
-      "src": "https://martincostello.azureedge.net/london-travel_android-chrome-36x36.png",
+      "src": "https://cdn.martincostello.com/london-travel_android-chrome-36x36.png",
       "sizes": "36x36",
       "type": "image/png"
     },
     {
-      "src": "https://martincostello.azureedge.net/london-travel_android-chrome-48x48.png",
+      "src": "https://cdn.martincostello.com/london-travel_android-chrome-48x48.png",
       "sizes": "48x48",
       "type": "image/png"
     },
     {
-      "src": "https://martincostello.azureedge.net/london-travel_android-chrome-72x72.png",
+      "src": "https://cdn.martincostello.com/london-travel_android-chrome-72x72.png",
       "sizes": "72x72",
       "type": "image/png"
     },
     {
-      "src": "https://martincostello.azureedge.net/london-travel_android-chrome-96x96.png",
+      "src": "https://cdn.martincostello.com/london-travel_android-chrome-96x96.png",
       "sizes": "96x96",
       "type": "image/png"
     },
     {
-      "src": "https://martincostello.azureedge.net/london-travel_android-chrome-144x144.png",
+      "src": "https://cdn.martincostello.com/london-travel_android-chrome-144x144.png",
       "sizes": "144x144",
       "type": "image/png"
     },
     {
-      "src": "https://martincostello.azureedge.net/london-travel_android-chrome-192x192.png",
+      "src": "https://cdn.martincostello.com/london-travel_android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "https://martincostello.azureedge.net/london-travel_android-chrome-250x250.png",
+      "src": "https://cdn.martincostello.com/london-travel_android-chrome-250x250.png",
       "sizes": "250x250",
       "type": "image/png"
     },
     {
-      "src": "https://martincostello.azureedge.net/london-travel_android-chrome-512x512.png",
+      "src": "https://cdn.martincostello.com/london-travel_android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/src/LondonTravel.Site/wwwroot/not-found.html
+++ b/src/LondonTravel.Site/wwwroot/not-found.html
@@ -7,7 +7,7 @@
     <meta name="referrer" content="no-referrer-when-downgrade" />
     <meta name="robots" content="NOINDEX" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1, maximum-scale=1" />
-    <link rel="shortcut icon" type="image/x-icon" href="https://martincostello.azureedge.net/london-travel_favicon.ico" />
+    <link rel="shortcut icon" type="image/x-icon" href="https://cdn.martincostello.com/london-travel_favicon.ico" />
 </head>
 <body>
     <nav class="navbar navbar-default navbar-fixed-top">
@@ -15,7 +15,7 @@
             <div class="navbar-header">
                 <a class="navbar-brand" title="View the homepage" href="/">
                     <span>
-                        <img src="https://martincostello.azureedge.net/london-travel_avatar.png" alt="London Travel" title="London Travel" aria-hidden="true" />
+                        <img src="https://cdn.martincostello.com/london-travel_avatar.png" alt="London Travel" title="London Travel" aria-hidden="true" />
                         London Travel
                     </span>
                 </a>


### PR DESCRIPTION
Revert #725 to use the custom CDN domain now that Verizon have reissued the TLS certificate so that it is valid for the domain name.