### PR TITLE
Fix Swagger document URL

### DIFF
--- a/src/LondonTravel.Site/Views/Docs/Index.cshtml
+++ b/src/LondonTravel.Site/Views/Docs/Index.cshtml
@@ -36,7 +36,7 @@
 </svg>
 
 @section links {
-    <link rel="swagger" href="@Url.AbsoluteContent("swagger/api/swagger.json")" />
+    <link rel="swagger" href="@Url.AbsoluteContent("~/swagger/api/swagger.json")" />
 }
 
 @section scripts {


### PR DESCRIPTION
Use an application-relative path instead of a page-relative one.
