### PR TITLE
Remove redundant code for TF_BUILD

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,14 +9,14 @@
     <Authors>martin_costello</Authors>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)LondonTravel.Site.ruleset</CodeAnalysisRuleSet>
     <Company>https://github.com/martincostello/alexa-london-travel-site</Company>
-    <ContinuousIntegrationBuild Condition=" '$(CI)' != '' or '$(TF_BUILD)' != '' ">true</ContinuousIntegrationBuild>
+    <ContinuousIntegrationBuild Condition=" '$(CI)' != '' ">true</ContinuousIntegrationBuild>
     <Copyright>Martin Costello (c) $([System.DateTime]::UtcNow.ToString(yyyy))</Copyright>
     <Deterministic>true</Deterministic>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <GenerateGitMetadata Condition=" ('$(CI)' != '' or '$(TF_BUILD)' != '') and '$(GenerateGitMetadata)' == '' ">true</GenerateGitMetadata>
+    <GenerateGitMetadata Condition=" '$(CI)' != '' and '$(GenerateGitMetadata)' == '' ">true</GenerateGitMetadata>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
@@ -36,7 +36,7 @@
     <VersionPrefix>3.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(CI)' != '' or '$(TF_BUILD)' != '' or !Exists('$(MSBuildThisFileDirectory)\src\LondonTravel.Site\node_modules') ">
+  <PropertyGroup Condition=" '$(CI)' != '' or !Exists('$(MSBuildThisFileDirectory)\src\LondonTravel.Site\node_modules') ">
     <InstallWebPackages>true</InstallWebPackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(BuildingInsideVisualStudio)' == '' ">

--- a/src/LondonTravel.Site/LondonTravel.Site.csproj
+++ b/src/LondonTravel.Site/LondonTravel.Site.csproj
@@ -53,7 +53,7 @@
   <Target Name="PrepublishScript" DependsOnTargets="BundleAssets" BeforeTargets="Publish">
     <Exec Command="npm run publish" />
   </Target>
-  <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths" Condition="'$(CI)' != '' or '$(TF_BUILD)' != ''">
+  <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths" Condition=" '$(CI)' != '' ">
     <ItemGroup>
       <Content Include="wwwroot/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Content)" />
       <Content Include="wwwroot/.well-known/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes)" />

--- a/tests/LondonTravel.Site.Tests/Integration/BrowserTest.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/BrowserTest.cs
@@ -8,7 +8,6 @@ namespace MartinCostello.LondonTravel.Site.Integration
     using System.IO;
     using System.Linq;
     using System.Runtime.CompilerServices;
-    using System.Runtime.InteropServices;
     using System.Threading.Tasks;
     using JustEat.HttpClientInterception;
     using Microsoft.Extensions.Logging;
@@ -106,13 +105,6 @@ namespace MartinCostello.LondonTravel.Site.Integration
             if (!isDebuggerAttached)
             {
                 options.AddArgument("--headless");
-            }
-
-            // HACK Workaround for "(unknown error: DevToolsActivePort file doesn't exist)"
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TF_BUILD")) &&
-                RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                options.AddArgument("--no-sandbox");
             }
 
             options.SetLoggingPreference(LogType.Browser, LogLevel.All);


### PR DESCRIPTION
Remove redundant checks for `TF_BUILD` and code workarounds for building in VSTS.
