### PR TITLE
Improve port binding in tests

### DIFF
--- a/tests/LondonTravel.Site.Tests/Extensions/IHostExtensions.cs
+++ b/tests/LondonTravel.Site.Tests/Extensions/IHostExtensions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Site.Extensions
+{
+    using System;
+    using System.Linq;
+    using Microsoft.AspNetCore.Hosting.Server;
+    using Microsoft.AspNetCore.Hosting.Server.Features;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+
+    internal static class IHostExtensions
+    {
+        public static Uri GetAddress(this IHost host)
+        {
+            var server = host.Services.GetRequiredService<IServer>();
+
+            return server.Features.Get<IServerAddressesFeature>().Addresses
+                .Select((p) => new Uri(p))
+                .First();
+        }
+    }
+}

--- a/tests/LondonTravel.Site.Tests/Integration/AlexaTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/AlexaTests.cs
@@ -137,10 +137,10 @@ namespace MartinCostello.LondonTravel.Site.Integration
         {
             var queryString = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
             {
-                { "client_id", "alexa-london-travel" },
-                { "redirect_uri", new Uri(navigator.BaseUri, new Uri("/manage/", UriKind.Relative)).ToString() },
-                { "response_type", "token" },
-                { "state", "my_state" },
+                ["client_id"] = "alexa-london-travel",
+                ["redirect_uri"] = new Uri(navigator.BaseUri, new Uri("/manage/", UriKind.Relative)).ToString(),
+                ["response_type"] = "token",
+                ["state"] = "my_state",
             };
 
             string uriString = QueryHelpers.AddQueryString("/alexa/authorize/", queryString);

--- a/tests/LondonTravel.Site.Tests/Integration/RemoteAuthorizationEventsFilter.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/RemoteAuthorizationEventsFilter.cs
@@ -7,11 +7,13 @@ namespace MartinCostello.LondonTravel.Site.Integration
     using System.Collections.Specialized;
     using System.Threading.Tasks;
     using System.Web;
+    using MartinCostello.LondonTravel.Site.Extensions;
     using MartinCostello.LondonTravel.Site.Identity;
     using Microsoft.AspNetCore.Authentication;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
 
     /// <summary>
     /// A class representing a <see cref="IStartupFilter"/> that allows the tests to redirect external
@@ -19,12 +21,12 @@ namespace MartinCostello.LondonTravel.Site.Integration
     /// </summary>
     internal sealed class RemoteAuthorizationEventsFilter : IStartupFilter
     {
-        private readonly Uri _serverAddress;
-
-        public RemoteAuthorizationEventsFilter(Uri serverAddress)
+        public RemoteAuthorizationEventsFilter(IHost host)
         {
-            _serverAddress = serverAddress;
+            Host = host;
         }
+
+        private IHost Host { get; }
 
         /// <inheritdoc />
         public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
@@ -94,7 +96,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
             queryString.Add("oauth_token", oauthToken);
             queryString.Add("oauth_verifier", verifier);
 
-            var builder = new UriBuilder(_serverAddress)
+            var builder = new UriBuilder(Host.GetAddress())
             {
                 Path = "/signin-twitter",
                 Query = queryString.ToString() ?? string.Empty,


### PR DESCRIPTION
Dynamically bind the port without needing to use a `TcpListener`.
