### PR TITLE
Skip Google test in CI

### DIFF
--- a/tests/LondonTravel.Site.Tests/EndToEnd/SocialLoginTests.cs
+++ b/tests/LondonTravel.Site.Tests/EndToEnd/SocialLoginTests.cs
@@ -21,6 +21,10 @@ namespace MartinCostello.LondonTravel.Site.EndToEnd
         [SkippableFact]
         public void Can_Sign_In_With_Google()
         {
+            Skip.IfNot(
+                string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS")),
+                "Sign-in blocked when run in GitHub Actions.");
+
             SignInWithSocialProvider(
                 "Google",
                 (driver, userName, password) =>


### PR DESCRIPTION
Skip the Google sign in test as it gets blocked when run in GitHub Actions.
