### PR TITLE
Skip Microsoft Account test

### DIFF
--- a/tests/LondonTravel.Site.Tests/EndToEnd/SocialLoginTests.cs
+++ b/tests/LondonTravel.Site.Tests/EndToEnd/SocialLoginTests.cs
@@ -43,6 +43,10 @@ namespace MartinCostello.LondonTravel.Site.EndToEnd
         [SkippableFact]
         public void Can_Sign_In_With_Microsoft_Account()
         {
+            Skip.IfNot(
+                string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS")),
+                "Sign-in is being flaky in GitHub Actions.");
+
             SignInWithSocialProvider(
                 "Microsoft",
                 (driver, userName, password) =>


### PR DESCRIPTION
Skip the test for logging in with a Microsoft Account as it's being flaky and causing deployments to fail.