### PR TITLE
Move using statements

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,7 +50,7 @@
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
+    <PackageReference Include="coverlet.msbuild" PrivateAssets="All" Condition=" '$(IsTestProject)' == 'true' " />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />

--- a/src/LondonTravel.Site/AzureEnvironmentSecretManager.cs
+++ b/src/LondonTravel.Site/AzureEnvironmentSecretManager.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using Azure.Extensions.AspNetCore.Configuration.Secrets;
+using Azure.Security.KeyVault.Secrets;
+
 namespace MartinCostello.LondonTravel.Site
 {
-    using System;
-    using Azure.Extensions.AspNetCore.Configuration.Secrets;
-    using Azure.Security.KeyVault.Secrets;
-
     /// <summary>
     /// A class representing an implementation of <see cref="KeyVaultSecretManager"/>
     /// that selects keys based on the Azure environment name. This class cannot be inherited.

--- a/src/LondonTravel.Site/Controllers/AccountController.cs
+++ b/src/LondonTravel.Site/Controllers/AccountController.cs
@@ -1,22 +1,22 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+using MartinCostello.LondonTravel.Site.Options;
+using MartinCostello.LondonTravel.Site.Telemetry;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using System;
-    using System.Linq;
-    using System.Security.Claims;
-    using System.Threading.Tasks;
-    using Identity;
-    using Microsoft.AspNetCore.Authentication;
-    using Microsoft.AspNetCore.Authorization;
-    using Microsoft.AspNetCore.Identity;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Extensions.Logging;
-    using NodaTime;
-    using Options;
-    using Telemetry;
-
     /// <summary>
     /// A class representing the controller for the <c>/account/</c> resource.
     /// </summary>

--- a/src/LondonTravel.Site/Controllers/AlexaController.cs
+++ b/src/LondonTravel.Site/Controllers/AlexaController.cs
@@ -1,20 +1,20 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+using MartinCostello.LondonTravel.Site.Options;
+using MartinCostello.LondonTravel.Site.Telemetry;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using System;
-    using System.Linq;
-    using System.Security.Cryptography;
-    using System.Threading.Tasks;
-    using Identity;
-    using Microsoft.AspNetCore.Authorization;
-    using Microsoft.AspNetCore.Identity;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Extensions.Logging;
-    using Options;
-    using Telemetry;
-
     /// <summary>
     /// A class representing the controller for the <c>/alexa</c> resource.
     /// </summary>

--- a/src/LondonTravel.Site/Controllers/ApiController.cs
+++ b/src/LondonTravel.Site/Controllers/ApiController.cs
@@ -1,23 +1,23 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Net.Http.Headers;
+using System.Net.Mime;
+using System.Threading;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+using MartinCostello.LondonTravel.Site.Models;
+using MartinCostello.LondonTravel.Site.Services;
+using MartinCostello.LondonTravel.Site.Swagger;
+using MartinCostello.LondonTravel.Site.Telemetry;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using System;
-    using System.Net.Http.Headers;
-    using System.Net.Mime;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Identity;
-    using MartinCostello.LondonTravel.Site.Services;
-    using MartinCostello.LondonTravel.Site.Swagger;
-    using Microsoft.AspNetCore.Authorization;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Extensions.Logging;
-    using Models;
-    using Telemetry;
-
     /// <summary>
     /// A class representing the controller for the <c>/api</c> resource.
     /// </summary>

--- a/src/LondonTravel.Site/Controllers/DocsController.cs
+++ b/src/LondonTravel.Site/Controllers/DocsController.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Microsoft.AspNetCore.Mvc;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using Microsoft.AspNetCore.Mvc;
-
     /// <summary>
     /// A class representing the controller for the <c>/api</c> resource.
     /// </summary>

--- a/src/LondonTravel.Site/Controllers/ErrorController.cs
+++ b/src/LondonTravel.Site/Controllers/ErrorController.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Net;
+using System.Security.Cryptography;
+using MartinCostello.LondonTravel.Site.Telemetry;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using System;
-    using System.Net;
-    using System.Security.Cryptography;
-    using MartinCostello.LondonTravel.Site.Telemetry;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc;
-
     /// <summary>
     /// A class representing the controller for the <c>/error</c> resource.
     /// </summary>

--- a/src/LondonTravel.Site/Controllers/HelpController.cs
+++ b/src/LondonTravel.Site/Controllers/HelpController.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+using MartinCostello.LondonTravel.Site.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using System.Threading.Tasks;
-    using Identity;
-    using Microsoft.AspNetCore.Identity;
-    using Microsoft.AspNetCore.Mvc;
-    using Models;
-
     /// <summary>
     /// A class representing the controller for the <c>/help/</c> resource.
     /// </summary>

--- a/src/LondonTravel.Site/Controllers/HomeController.cs
+++ b/src/LondonTravel.Site/Controllers/HomeController.cs
@@ -1,20 +1,20 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+using MartinCostello.LondonTravel.Site.Models;
+using MartinCostello.LondonTravel.Site.Services.Tfl;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Identity;
-    using Microsoft.AspNetCore.Identity;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Extensions.Logging;
-    using Models;
-    using Services.Tfl;
-
     /// <summary>
     /// A class representing the controller for the <c>/</c> resource.
     /// </summary>

--- a/src/LondonTravel.Site/Controllers/ManageController.cs
+++ b/src/LondonTravel.Site/Controllers/ManageController.cs
@@ -1,23 +1,23 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+using MartinCostello.LondonTravel.Site.Models;
+using MartinCostello.LondonTravel.Site.Services.Tfl;
+using MartinCostello.LondonTravel.Site.Telemetry;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Identity;
-    using Microsoft.AspNetCore.Authentication;
-    using Microsoft.AspNetCore.Authorization;
-    using Microsoft.AspNetCore.Identity;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Extensions.Logging;
-    using Models;
-    using Services.Tfl;
-    using Telemetry;
-
     /// <summary>
     /// A class representing the controller for the <c>/manage/</c> resource.
     /// </summary>

--- a/src/LondonTravel.Site/Controllers/PrivacyPolicyController.cs
+++ b/src/LondonTravel.Site/Controllers/PrivacyPolicyController.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Microsoft.AspNetCore.Mvc;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using Microsoft.AspNetCore.Mvc;
-
     /// <summary>
     /// A class representing the controller for the <c>/privacy-policy/</c> resource.
     /// </summary>

--- a/src/LondonTravel.Site/Controllers/RegisterController.cs
+++ b/src/LondonTravel.Site/Controllers/RegisterController.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Models;
+using MartinCostello.LondonTravel.Site.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using System;
-    using System.Threading.Tasks;
-    using MartinCostello.LondonTravel.Site.Models;
-    using MartinCostello.LondonTravel.Site.Services;
-    using Microsoft.AspNetCore.Authorization;
-    using Microsoft.AspNetCore.Mvc;
-
     public class RegisterController : Controller
     {
         private readonly IAccountService _service;

--- a/src/LondonTravel.Site/Controllers/TechnologyController.cs
+++ b/src/LondonTravel.Site/Controllers/TechnologyController.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Microsoft.AspNetCore.Mvc;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using Microsoft.AspNetCore.Mvc;
-
     /// <summary>
     /// A class representing the controller for the <c>/technology/</c> resource.
     /// </summary>

--- a/src/LondonTravel.Site/Controllers/TermsController.cs
+++ b/src/LondonTravel.Site/Controllers/TermsController.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Microsoft.AspNetCore.Mvc;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using Microsoft.AspNetCore.Mvc;
-
     /// <summary>
     /// A class representing the controller for the <c>/terms-of-service/</c> resource.
     /// </summary>

--- a/src/LondonTravel.Site/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using System;
-    using System.Globalization;
-    using System.Linq;
-    using System.Security.Claims;
-    using System.Text;
-
     /// <summary>
     /// A class containing extension methods for the <see cref="ClaimsPrincipal"/> class. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Extensions/HttpContextExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/HttpContextExtensions.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Http;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using System;
-    using System.Security.Cryptography;
-    using Microsoft.AspNetCore.Http;
-
     /// <summary>
     /// A class containing extension methods for the <see cref="HttpContext"/> class. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Extensions/HttpRequestExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/HttpRequestExtensions.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Globalization;
+using Microsoft.AspNetCore.Http;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using System;
-    using System.Globalization;
-    using Microsoft.AspNetCore.Http;
-
     /// <summary>
     /// A class containing extension methods for the <see cref="HttpRequest"/> class. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Extensions/HttpServiceCollectionExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/HttpServiceCollectionExtensions.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Net.Http;
+using MartinCostello.LondonTravel.Site.Options;
+using MartinCostello.LondonTravel.Site.Services.Tfl;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Refit;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using System;
-    using System.Net.Http;
-    using MartinCostello.LondonTravel.Site.Services.Tfl;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Options;
-    using Options;
-    using Refit;
-
     /// <summary>
     /// A class containing HTTP-related extension methods for the <see cref="IServiceCollection"/> interface. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/IApplicationBuilderExtensions.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using MartinCostello.LondonTravel.Site.Middleware;
+using MartinCostello.LondonTravel.Site.Options;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.Options;
-    using Middleware;
-    using Options;
-
     /// <summary>
     /// A class containing extension methods for the <see cref="IApplicationBuilder"/> interface. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Extensions/IConfigurationExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/IConfigurationExtensions.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Microsoft.Extensions.Configuration;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using Microsoft.Extensions.Configuration;
-
     /// <summary>
     /// A class containing extension methods for <see cref="IConfiguration"/>. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Extensions/IHostBuilderExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/IHostBuilderExtensions.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using System;
-    using System.Diagnostics.CodeAnalysis;
-    using Azure.Core;
-    using Azure.Identity;
-    using Azure.Security.KeyVault.Secrets;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
-
     internal static class IHostBuilderExtensions
     {
         public static IHostBuilder ConfigureApplication(this IHostBuilder builder)

--- a/src/LondonTravel.Site/Extensions/IHtmlHelperExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/IHtmlHelperExtensions.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using System;
-    using System.Collections.Generic;
-    using Microsoft.AspNetCore.Mvc.Rendering;
-
     /// <summary>
     /// A class containing extension methods for the <see cref="IHtmlHelper"/> interface. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Extensions/IHttpClientBuilderExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/IHttpClientBuilderExtensions.cs
@@ -1,21 +1,21 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Polly;
+using Polly.Registry;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using System;
-    using System.Diagnostics;
-    using System.Net;
-    using System.Net.Http;
-    using System.Net.Http.Headers;
-    using System.Reflection;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.DependencyInjection;
-    using Polly;
-    using Polly.Registry;
-
     /// <summary>
     /// A class containing extension methods for the <see cref="IHttpClientBuilder"/> interface. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Extensions/ILoggingBuilderExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/ILoggingBuilderExtensions.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Serilog;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using Microsoft.Extensions.Hosting;
-    using Microsoft.Extensions.Logging;
-    using Serilog;
-
     /// <summary>
     /// A class containing extension methods for the <see cref="ILoggingBuilder"/> interface. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Extensions/IUrlHelperExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/IUrlHelperExtensions.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using MartinCostello.LondonTravel.Site.Options;
+using Microsoft.AspNetCore.Mvc;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using System;
-    using Microsoft.AspNetCore.Mvc;
-    using Options;
-
     /// <summary>
     /// A class containing extension methods for the <see cref="IUrlHelper"/> class. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Extensions/IdentityServiceCollectionExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/IdentityServiceCollectionExtensions.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using MartinCostello.LondonTravel.Site.Identity;
+using MartinCostello.LondonTravel.Site.Options;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using System;
-    using MartinCostello.LondonTravel.Site.Identity;
-    using Microsoft.AspNetCore.Authentication.Cookies;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Identity;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
-    using Options;
-
     /// <summary>
     /// A class containing extension methods for the <see cref="IServiceCollection"/> interface. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Extensions/LoggerSinkConfigurationExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/LoggerSinkConfigurationExtensions.cs
@@ -1,18 +1,18 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using Serilog;
+using Serilog.Configuration;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Formatting.Display;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using System.Globalization;
-    using System.IO;
-    using System.Linq;
-    using System.Net;
-    using Serilog;
-    using Serilog.Configuration;
-    using Serilog.Events;
-    using Serilog.Formatting;
-    using Serilog.Formatting.Display;
-
     /// <summary>
     /// A class containing extension methods for the <see cref="LoggerSinkConfiguration"/> class. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Extensions/PollyServiceCollectionExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/PollyServiceCollectionExtensions.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Polly;
+using Polly.Extensions.Http;
+using Polly.Registry;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using System;
-    using System.Net.Http;
-    using Microsoft.Extensions.DependencyInjection;
-    using Polly;
-    using Polly.Extensions.Http;
-    using Polly.Registry;
-
     /// <summary>
     /// A class containing Polly-related extension methods for the <see cref="IServiceCollection"/> interface. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Extensions/SwaggerServiceCollectionExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/SwaggerServiceCollectionExtensions.cs
@@ -1,19 +1,19 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.IO;
+using System.Reflection;
+using MartinCostello.LondonTravel.Site.Options;
+using MartinCostello.LondonTravel.Site.Swagger;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using System;
-    using System.IO;
-    using System.Reflection;
-    using MartinCostello.LondonTravel.Site.Swagger;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
-    using Microsoft.OpenApi.Models;
-    using Options;
-    using Swashbuckle.AspNetCore.SwaggerGen;
-
     /// <summary>
     /// A class containing Swagger-related extension methods for the <see cref="IServiceCollection"/> interface. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/GitMetadata.cs
+++ b/src/LondonTravel.Site/GitMetadata.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+
 namespace MartinCostello.LondonTravel.Site
 {
-    using System;
-    using System.Globalization;
-    using System.Linq;
-    using System.Reflection;
-
     /// <summary>
     /// A class containing Git metadata for the assembly. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Identity/AuthenticationBuilderExtensions.cs
+++ b/src/LondonTravel.Site/Identity/AuthenticationBuilderExtensions.cs
@@ -1,28 +1,28 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using AspNet.Security.OAuth.Amazon;
+using AspNet.Security.OAuth.Apple;
+using AspNet.Security.OAuth.GitHub;
+using Azure.Security.KeyVault.Secrets;
+using MartinCostello.LondonTravel.Site.Options;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Facebook;
+using Microsoft.AspNetCore.Authentication.Google;
+using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
+using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.Authentication.Twitter;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 namespace MartinCostello.LondonTravel.Site.Identity
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Net.Http;
-    using System.Threading.Tasks;
-    using AspNet.Security.OAuth.Amazon;
-    using AspNet.Security.OAuth.Apple;
-    using AspNet.Security.OAuth.GitHub;
-    using Azure.Security.KeyVault.Secrets;
-    using MartinCostello.LondonTravel.Site.Options;
-    using Microsoft.AspNetCore.Authentication;
-    using Microsoft.AspNetCore.Authentication.Facebook;
-    using Microsoft.AspNetCore.Authentication.Google;
-    using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
-    using Microsoft.AspNetCore.Authentication.OAuth;
-    using Microsoft.AspNetCore.Authentication.Twitter;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Logging;
-
     public static class AuthenticationBuilderExtensions
     {
         public static AuthenticationBuilder TryAddAmazon(

--- a/src/LondonTravel.Site/Identity/ExternalAuthEvents.cs
+++ b/src/LondonTravel.Site/Identity/ExternalAuthEvents.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.Authentication.Twitter;
+
 namespace MartinCostello.LondonTravel.Site.Identity
 {
-    using System;
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Authentication;
-    using Microsoft.AspNetCore.Authentication.OAuth;
-    using Microsoft.AspNetCore.Authentication.Twitter;
-
     /// <summary>
     /// A class for registering external authentication events. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Identity/LondonTravelLoginInfo.cs
+++ b/src/LondonTravel.Site/Identity/LondonTravelLoginInfo.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Identity;
+using Newtonsoft.Json;
+
 namespace MartinCostello.LondonTravel.Site.Identity
 {
-    using System.Text.Json.Serialization;
-    using Microsoft.AspNetCore.Identity;
-    using Newtonsoft.Json;
-
     /// <summary>
     /// A class representing external login information for a user.
     /// </summary>

--- a/src/LondonTravel.Site/Identity/LondonTravelRole.cs
+++ b/src/LondonTravel.Site/Identity/LondonTravelRole.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Security.Claims;
+using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+
 namespace MartinCostello.LondonTravel.Site.Identity
 {
-    using System;
-    using System.Security.Claims;
-    using System.Text.Json.Serialization;
-    using Newtonsoft.Json;
-
     /// <summary>
     /// A class representing a user role.
     /// </summary>

--- a/src/LondonTravel.Site/Identity/LondonTravelUser.cs
+++ b/src/LondonTravel.Site/Identity/LondonTravelUser.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+
 namespace MartinCostello.LondonTravel.Site.Identity
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Text.Json.Serialization;
-    using Newtonsoft.Json;
-
     /// <summary>
     /// A class representing a user of the application.
     /// </summary>

--- a/src/LondonTravel.Site/Identity/RoleStore.cs
+++ b/src/LondonTravel.Site/Identity/RoleStore.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+
 namespace MartinCostello.LondonTravel.Site.Identity
 {
-    using System;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Identity;
-
     /// <summary>
     /// A class representing a custom implementation of <see cref="IRoleStore{LondonTravelRole}"/>. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Identity/UserClaimsPrincipalFactory.cs
+++ b/src/LondonTravel.Site/Identity/UserClaimsPrincipalFactory.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
 namespace MartinCostello.LondonTravel.Site.Identity
 {
-    using System.Security.Claims;
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Identity;
-    using Microsoft.Extensions.Options;
-
     /// <summary>
     /// A custom implementation of <see cref="UserClaimsPrincipalFactory{LondonTravelUser, LondonTravelRole}"/>
     /// that adds additional claims to the principal when it is created by the application.

--- a/src/LondonTravel.Site/Identity/UserStore.cs
+++ b/src/LondonTravel.Site/Identity/UserStore.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Services.Data;
+using Microsoft.AspNetCore.Identity;
+
 namespace MartinCostello.LondonTravel.Site.Identity
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Security.Claims;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Identity;
-    using Services.Data;
-
     /// <summary>
     /// A class representing a custom implementation of a user store. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
@@ -1,22 +1,22 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Extensions;
+using MartinCostello.LondonTravel.Site.Options;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
 namespace MartinCostello.LondonTravel.Site.Middleware
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Globalization;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using Extensions;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.Hosting;
-    using Microsoft.Extensions.Options;
-    using Options;
-
     /// <summary>
     /// A class representing middleware for adding custom HTTP response headers. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Models/DocumentCount.cs
+++ b/src/LondonTravel.Site/Models/DocumentCount.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Text.Json.Serialization;
+
 namespace MartinCostello.LondonTravel.Site.Models
 {
-    using System.Text.Json.Serialization;
-
     /// <summary>
     /// A class representing the number of documents in the document store. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Models/ErrorResponse.cs
+++ b/src/LondonTravel.Site/Models/ErrorResponse.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using MartinCostello.LondonTravel.Site.Swagger;
+
 namespace MartinCostello.LondonTravel.Site.Models
 {
-    using System.Collections.Generic;
-    using System.ComponentModel.DataAnnotations;
-    using System.Text.Json.Serialization;
-    using MartinCostello.LondonTravel.Site.Swagger;
-
     /// <summary>
     /// Represents an error from an API resource.
     /// </summary>

--- a/src/LondonTravel.Site/Models/LinePreferencesViewModel.cs
+++ b/src/LondonTravel.Site/Models/LinePreferencesViewModel.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace MartinCostello.LondonTravel.Site.Models
 {
-    using System.Collections.Generic;
-    using System.Linq;
-
     /// <summary>
     /// A class representing the view model for a user's line preferences.
     /// </summary>

--- a/src/LondonTravel.Site/Models/ManageViewModel.cs
+++ b/src/LondonTravel.Site/Models/ManageViewModel.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+
 namespace MartinCostello.LondonTravel.Site.Models
 {
-    using System;
-    using System.Collections.Generic;
-    using Microsoft.AspNetCore.Authentication;
-    using Microsoft.AspNetCore.Identity;
-
     public class ManageViewModel
     {
         public IList<UserLoginInfo> CurrentLogins { get; set; } = Array.Empty<UserLoginInfo>();

--- a/src/LondonTravel.Site/Models/MetaModel.cs
+++ b/src/LondonTravel.Site/Models/MetaModel.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Linq;
+using MartinCostello.LondonTravel.Site.Options;
+
 namespace MartinCostello.LondonTravel.Site.Models
 {
-    using System;
-    using System.Linq;
-    using Options;
-
     /// <summary>
     /// A class representing the view model for page metadata. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Models/PreferencesResponse.cs
+++ b/src/LondonTravel.Site/Models/PreferencesResponse.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
 namespace MartinCostello.LondonTravel.Site.Models
 {
-    using System.Collections.Generic;
-    using System.ComponentModel.DataAnnotations;
-    using System.Text.Json.Serialization;
-
     /// <summary>
     /// Represents the API response for a user's preferences.
     /// </summary>

--- a/src/LondonTravel.Site/Models/UpdateLinePreferencesViewModel.cs
+++ b/src/LondonTravel.Site/Models/UpdateLinePreferencesViewModel.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace MartinCostello.LondonTravel.Site.Models
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// A class representing the view model to update a user's line preferences.
     /// </summary>

--- a/src/LondonTravel.Site/Options/AlexaOptions.cs
+++ b/src/LondonTravel.Site/Options/AlexaOptions.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace MartinCostello.LondonTravel.Site.Options
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// A class representing the Alexa options for the site. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Options/AuthenticationOptions.cs
+++ b/src/LondonTravel.Site/Options/AuthenticationOptions.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace MartinCostello.LondonTravel.Site.Options
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// A class representing the authentication options for the site. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Options/CertificateTransparencyOptions.cs
+++ b/src/LondonTravel.Site/Options/CertificateTransparencyOptions.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+
 namespace MartinCostello.LondonTravel.Site.Options
 {
-    using System;
-
     /// <summary>
     /// A class representing the options to use for the <c>Expect-CT</c>
     /// HTTP response header. This class cannot be inherited.

--- a/src/LondonTravel.Site/Options/ExternalLinksOptions.cs
+++ b/src/LondonTravel.Site/Options/ExternalLinksOptions.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+
 namespace MartinCostello.LondonTravel.Site.Options
 {
-    using System;
-
     /// <summary>
     /// A class representing the external link options for the site. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Options/ReportOptions.cs
+++ b/src/LondonTravel.Site/Options/ReportOptions.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+
 namespace MartinCostello.LondonTravel.Site.Options
 {
-    using System;
-
     /// <summary>
     /// A class representing the options for reports. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Options/SiteOptions.cs
+++ b/src/LondonTravel.Site/Options/SiteOptions.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace MartinCostello.LondonTravel.Site.Options
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// A class representing the site configuration. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Options/TflOptions.cs
+++ b/src/LondonTravel.Site/Options/TflOptions.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+
 namespace MartinCostello.LondonTravel.Site.Options
 {
-    using System;
-    using System.Collections.Generic;
-
     /// <summary>
     /// A class representing the options for the TfL API integration. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Options/UserStoreOptions.cs
+++ b/src/LondonTravel.Site/Options/UserStoreOptions.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+
 namespace MartinCostello.LondonTravel.Site.Options
 {
-    using System;
-
     /// <summary>
     /// A class representing the authentication user store options for the site. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Program.cs
+++ b/src/LondonTravel.Site/Program.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using MartinCostello.LondonTravel.Site.Extensions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
 namespace MartinCostello.LondonTravel.Site
 {
-    using System;
-    using Extensions;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.Hosting;
-
     /// <summary>
     /// A class representing the entry-point to the application. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Services/AccountService.cs
+++ b/src/LondonTravel.Site/Services/AccountService.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+using MartinCostello.LondonTravel.Site.Services.Data;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
 namespace MartinCostello.LondonTravel.Site.Services
 {
-    using System;
-    using System.Linq;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using MartinCostello.LondonTravel.Site.Identity;
-    using MartinCostello.LondonTravel.Site.Services.Data;
-    using Microsoft.Extensions.Caching.Memory;
-    using Microsoft.Extensions.Logging;
-
     public class AccountService : IAccountService
     {
         /// <summary>

--- a/src/LondonTravel.Site/Services/Data/DocumentCollectionInitializer.cs
+++ b/src/LondonTravel.Site/Services/Data/DocumentCollectionInitializer.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Options;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+
 namespace MartinCostello.LondonTravel.Site.Services.Data
 {
-    using System;
-    using System.Collections.Concurrent;
-    using System.Net;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos;
-    using Microsoft.Extensions.Logging;
-    using Options;
-
     /// <summary>
     /// A class representing the default implementation of
     /// <see cref="IDocumentCollectionInitializer"/>. This class cannot be inherited.

--- a/src/LondonTravel.Site/Services/Data/DocumentHelpers.cs
+++ b/src/LondonTravel.Site/Services/Data/DocumentHelpers.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Net.Http;
+using MartinCostello.LondonTravel.Site.Options;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Fluent;
+using Microsoft.Extensions.DependencyInjection;
+
 namespace MartinCostello.LondonTravel.Site.Services.Data
 {
-    using System;
-    using System.Net.Http;
-    using Microsoft.Azure.Cosmos;
-    using Microsoft.Azure.Cosmos.Fluent;
-    using Microsoft.Extensions.DependencyInjection;
-    using Options;
-
     /// <summary>
     /// A class containing helper methods for DocumentDB operations. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Services/Data/DocumentService.cs
+++ b/src/LondonTravel.Site/Services/Data/DocumentService.cs
@@ -1,21 +1,21 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+using MartinCostello.LondonTravel.Site.Options;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Linq;
+using Microsoft.Extensions.Logging;
+
 namespace MartinCostello.LondonTravel.Site.Services.Data
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Linq.Expressions;
-    using System.Net;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using MartinCostello.LondonTravel.Site.Identity;
-    using Microsoft.Azure.Cosmos;
-    using Microsoft.Azure.Cosmos.Linq;
-    using Microsoft.Extensions.Logging;
-    using Options;
-
     /// <summary>
     /// A class representing an implementation of <see cref="IDocumentService"/>. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Services/Data/IDocumentCollectionInitializer.cs
+++ b/src/LondonTravel.Site/Services/Data/IDocumentCollectionInitializer.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+
 namespace MartinCostello.LondonTravel.Site.Services.Data
 {
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos;
-
     /// <summary>
     /// Defines a document collection initializer.
     /// </summary>

--- a/src/LondonTravel.Site/Services/Data/IDocumentService.cs
+++ b/src/LondonTravel.Site/Services/Data/IDocumentService.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+
 namespace MartinCostello.LondonTravel.Site.Services.Data
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq.Expressions;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using MartinCostello.LondonTravel.Site.Identity;
-
     /// <summary>
     /// Defines a document database service.
     /// </summary>

--- a/src/LondonTravel.Site/Services/Data/SystemTextJsonCosmosSerializer.cs
+++ b/src/LondonTravel.Site/Services/Data/SystemTextJsonCosmosSerializer.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.IO;
+using System.Text.Json;
+using Microsoft.Azure.Cosmos;
+
 namespace MartinCostello.LondonTravel.Site.Services.Data
 {
-    using System.IO;
-    using System.Text.Json;
-    using Microsoft.Azure.Cosmos;
-
     internal sealed class SystemTextJsonCosmosSerializer : CosmosSerializer
     {
         private readonly JsonSerializerOptions _options;

--- a/src/LondonTravel.Site/Services/IAccountService.cs
+++ b/src/LondonTravel.Site/Services/IAccountService.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Threading;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+
 namespace MartinCostello.LondonTravel.Site.Services
 {
-    using System.Threading;
-    using System.Threading.Tasks;
-    using MartinCostello.LondonTravel.Site.Identity;
-
     /// <summary>
     /// Defines operations for account management.
     /// </summary>

--- a/src/LondonTravel.Site/Services/Tfl/ITflClient.cs
+++ b/src/LondonTravel.Site/Services/Tfl/ITflClient.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Refit;
+
 namespace MartinCostello.LondonTravel.Site.Services.Tfl
 {
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Refit;
-
     /// <summary>
     /// Defines an HTTP client for the TfL API.
     /// </summary>

--- a/src/LondonTravel.Site/Services/Tfl/ITflService.cs
+++ b/src/LondonTravel.Site/Services/Tfl/ITflService.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace MartinCostello.LondonTravel.Site.Services.Tfl
 {
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-
     /// <summary>
     /// Defines the TfL API service.
     /// </summary>

--- a/src/LondonTravel.Site/Services/Tfl/LineInfo.cs
+++ b/src/LondonTravel.Site/Services/Tfl/LineInfo.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Text.Json.Serialization;
+
 namespace MartinCostello.LondonTravel.Site.Services.Tfl
 {
-    using System.Text.Json.Serialization;
-
     /// <summary>
     /// A class representing information about a line. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Services/Tfl/StopPoint.cs
+++ b/src/LondonTravel.Site/Services/Tfl/StopPoint.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Text.Json.Serialization;
+
 namespace MartinCostello.LondonTravel.Site.Services.Tfl
 {
-    using System.Text.Json.Serialization;
-
     /// <summary>
     /// A class representing information about a stop point on a line. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Services/Tfl/TflService.cs
+++ b/src/LondonTravel.Site/Services/Tfl/TflService.cs
@@ -1,16 +1,16 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Options;
+using Microsoft.Extensions.Caching.Memory;
+using Refit;
+
 namespace MartinCostello.LondonTravel.Site.Services.Tfl
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.Extensions.Caching.Memory;
-    using Options;
-    using Refit;
-
     /// <summary>
     /// A class representing the default implementation of <see cref="ITflService"/>.
     /// </summary>

--- a/src/LondonTravel.Site/Services/Tfl/TflServiceFactory.cs
+++ b/src/LondonTravel.Site/Services/Tfl/TflServiceFactory.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
 namespace MartinCostello.LondonTravel.Site.Services.Tfl
 {
-    using System;
-    using Microsoft.Extensions.DependencyInjection;
-
     /// <summary>
     /// A class representing the default implementation of <see cref="ITflServiceFactory"/>. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/SiteContext.cs
+++ b/src/LondonTravel.Site/SiteContext.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Microsoft.AspNetCore.Authentication;
+
 namespace MartinCostello.LondonTravel.Site
 {
-    using Microsoft.AspNetCore.Authentication;
-
     /// <summary>
     /// A class containing site contexts. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/SiteResources.cs
+++ b/src/LondonTravel.Site/SiteResources.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using MartinCostello.LondonTravel.Site.Options;
+using Microsoft.AspNetCore.Mvc.Localization;
+using Microsoft.Extensions.Localization;
+
 namespace MartinCostello.LondonTravel.Site
 {
-    using System;
-    using MartinCostello.LondonTravel.Site.Options;
-    using Microsoft.AspNetCore.Mvc.Localization;
-    using Microsoft.Extensions.Localization;
-
     /// <summary>
     /// A class representing the container for site resource strings.
     /// </summary>

--- a/src/LondonTravel.Site/Startup.cs
+++ b/src/LondonTravel.Site/Startup.cs
@@ -1,37 +1,37 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.IO;
+using System.Net.Mime;
+using MartinCostello.LondonTravel.Site.Extensions;
+using MartinCostello.LondonTravel.Site.Options;
+using MartinCostello.LondonTravel.Site.Services;
+using MartinCostello.LondonTravel.Site.Services.Data;
+using MartinCostello.LondonTravel.Site.Services.Tfl;
+using MartinCostello.LondonTravel.Site.Telemetry;
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.CookiePolicy;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+using NodaTime;
+
 namespace MartinCostello.LondonTravel.Site
 {
-    using System;
-    using System.IO;
-    using System.Net.Mime;
-    using Extensions;
-    using MartinCostello.LondonTravel.Site.Services;
-    using Microsoft.ApplicationInsights.AspNetCore.Extensions;
-    using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.AspNetCore.CookiePolicy;
-    using Microsoft.AspNetCore.Cors.Infrastructure;
-    using Microsoft.AspNetCore.DataProtection;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.HttpOverrides;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.AspNetCore.Mvc.Razor;
-    using Microsoft.AspNetCore.StaticFiles;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.DependencyInjection.Extensions;
-    using Microsoft.Extensions.Hosting;
-    using Microsoft.Extensions.Options;
-    using Microsoft.Net.Http.Headers;
-    using NodaTime;
-    using Options;
-    using Services.Data;
-    using Services.Tfl;
-    using Telemetry;
-
     /// <summary>
     /// A class representing the startup logic for the application.
     /// </summary>

--- a/src/LondonTravel.Site/Swagger/ApiExplorerDisplayConvention.cs
+++ b/src/LondonTravel.Site/Swagger/ApiExplorerDisplayConvention.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Linq;
+using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
 namespace MartinCostello.LondonTravel.Site.Swagger
 {
-    using System.Linq;
-    using System.Net.Mime;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.AspNetCore.Mvc.ApplicationModels;
-
     /// <summary>
     /// A class representing the convention for displaying routes in API documentation. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Swagger/ErrorResponseExampleProvider.cs
+++ b/src/LondonTravel.Site/Swagger/ErrorResponseExampleProvider.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using MartinCostello.LondonTravel.Site.Models;
+
 namespace MartinCostello.LondonTravel.Site.Swagger
 {
-    using Models;
-
     /// <summary>
     /// A class representing an implementation of <see cref="IExampleProvider"/>
     /// for the <see cref="ErrorResponse"/> class. This class cannot be inherited.

--- a/src/LondonTravel.Site/Swagger/ExampleFilter.cs
+++ b/src/LondonTravel.Site/Swagger/ExampleFilter.cs
@@ -1,19 +1,19 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
 namespace MartinCostello.LondonTravel.Site.Swagger
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-    using System.Text.Json;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Extensions.Options;
-    using Microsoft.OpenApi.Any;
-    using Microsoft.OpenApi.Models;
-    using Swashbuckle.AspNetCore.SwaggerGen;
-
     /// <summary>
     /// A class representing an operation filter that adds the example to use for display in Swagger documentation. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Swagger/PreferencesResponseExampleProvider.cs
+++ b/src/LondonTravel.Site/Swagger/PreferencesResponseExampleProvider.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using MartinCostello.LondonTravel.Site.Models;
+
 namespace MartinCostello.LondonTravel.Site.Swagger
 {
-    using Models;
-
     /// <summary>
     /// A class representing an implementation of <see cref="IExampleProvider"/>
     /// for the <see cref="PreferencesResponse"/> class. This class cannot be inherited.

--- a/src/LondonTravel.Site/Swagger/RemoveStyleCopPrefixesFilter.cs
+++ b/src/LondonTravel.Site/Swagger/RemoveStyleCopPrefixesFilter.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
 namespace MartinCostello.LondonTravel.Site.Swagger
 {
-    using System;
-    using Microsoft.OpenApi.Models;
-    using Swashbuckle.AspNetCore.SwaggerGen;
-
     /// <summary>
     /// A class representing an operation filter that modifies XML documentation that matches <c>StyleCop</c>
     /// requirements to be more human-readable for display in Swagger documentation. This class cannot be inherited.

--- a/src/LondonTravel.Site/Swagger/SwaggerResponseExampleAttribute.cs
+++ b/src/LondonTravel.Site/Swagger/SwaggerResponseExampleAttribute.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+
 namespace MartinCostello.LondonTravel.Site.Swagger
 {
-    using System;
-
     /// <summary>
     /// Defines an example response for an API method. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Swagger/SwaggerTypeExampleAttribute.cs
+++ b/src/LondonTravel.Site/Swagger/SwaggerTypeExampleAttribute.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+
 namespace MartinCostello.LondonTravel.Site.Swagger
 {
-    using System;
-
     /// <summary>
     /// Defines an example response for an API method. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/TagHelpers/InlineStyleTagHelper.cs
+++ b/src/LondonTravel.Site/TagHelpers/InlineStyleTagHelper.cs
@@ -1,23 +1,23 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Razor.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.FileProviders;
+
 namespace MartinCostello.LondonTravel.Site.TagHelpers
 {
-    using System;
-    using System.IO;
-    using System.Linq;
-    using System.Text;
-    using System.Text.Encodings.Web;
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.Mvc.Razor.Infrastructure;
-    using Microsoft.AspNetCore.Mvc.Routing;
-    using Microsoft.AspNetCore.Mvc.TagHelpers;
-    using Microsoft.AspNetCore.Mvc.ViewFeatures;
-    using Microsoft.AspNetCore.Razor.TagHelpers;
-    using Microsoft.Extensions.Caching.Memory;
-    using Microsoft.Extensions.FileProviders;
-
     /// <summary>
     /// A <see cref="ITagHelper"/> implementation targeting &lt;link&gt;
     /// elements that supports inlining styles for local CSS files.

--- a/src/LondonTravel.Site/TagHelpers/LazyImageTagHelper.cs
+++ b/src/LondonTravel.Site/TagHelpers/LazyImageTagHelper.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
 namespace MartinCostello.LondonTravel.Site.TagHelpers
 {
-    using System.Text.Encodings.Web;
-    using Microsoft.AspNetCore.Mvc.Routing;
-    using Microsoft.AspNetCore.Mvc.TagHelpers;
-    using Microsoft.AspNetCore.Mvc.ViewFeatures;
-    using Microsoft.AspNetCore.Razor.TagHelpers;
-
     /// <summary>
     /// A <see cref="ITagHelper"/> implementation targeting &lt;lazyimg&gt;
     /// elements that supports file versioning and lazy loading of images.

--- a/src/LondonTravel.Site/TagHelpers/SriScriptTagHelper.cs
+++ b/src/LondonTravel.Site/TagHelpers/SriScriptTagHelper.cs
@@ -1,21 +1,21 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Security.Cryptography;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Razor.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.FileProviders;
+
 namespace MartinCostello.LondonTravel.Site.TagHelpers
 {
-    using System;
-    using System.Security.Cryptography;
-    using System.Text.Encodings.Web;
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.Mvc.Razor.Infrastructure;
-    using Microsoft.AspNetCore.Mvc.Routing;
-    using Microsoft.AspNetCore.Mvc.TagHelpers;
-    using Microsoft.AspNetCore.Mvc.ViewFeatures;
-    using Microsoft.AspNetCore.Razor.TagHelpers;
-    using Microsoft.Extensions.Caching.Memory;
-    using Microsoft.Extensions.FileProviders;
-
     /// <summary>
     /// A <see cref="ITagHelper"/> implementation targeting &lt;script&gt; elements to add subresource integrity attributes.
     /// </summary>

--- a/src/LondonTravel.Site/Telemetry/ISiteTelemetry.cs
+++ b/src/LondonTravel.Site/Telemetry/ISiteTelemetry.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace MartinCostello.LondonTravel.Site.Telemetry
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// Defines the interface for recording telemetry.
     /// </summary>

--- a/src/LondonTravel.Site/Telemetry/ISiteTelemetryExtensions.cs
+++ b/src/LondonTravel.Site/Telemetry/ISiteTelemetryExtensions.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+
 namespace MartinCostello.LondonTravel.Site.Telemetry
 {
-    using System;
-    using System.Collections.Generic;
-
     /// <summary>
     /// A class containing extension methods for the <see cref="ISiteTelemetry"/> interface. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Telemetry/SiteTelemetry.cs
+++ b/src/LondonTravel.Site/Telemetry/SiteTelemetry.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using Microsoft.ApplicationInsights;
+
 namespace MartinCostello.LondonTravel.Site.Telemetry
 {
-    using System.Collections.Generic;
-    using Microsoft.ApplicationInsights;
-
     /// <summary>
     /// A class representing the default implementation of <see cref="ISiteTelemetry"/>. This class cannot be inherited.
     /// </summary>

--- a/src/LondonTravel.Site/Telemetry/SiteTelemetryInitializer.cs
+++ b/src/LondonTravel.Site/Telemetry/SiteTelemetryInitializer.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Net.Http;
+using System.Net.Http.Headers;
+using MartinCostello.LondonTravel.Site.Extensions;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+
 namespace MartinCostello.LondonTravel.Site.Telemetry
 {
-    using System.Net.Http;
-    using System.Net.Http.Headers;
-    using Extensions;
-    using Microsoft.ApplicationInsights.Channel;
-    using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.Configuration;
-
     /// <summary>
     /// A class representing an Application Insights initializer for custom telemetry setup. This class cannot be inherited.
     /// </summary>

--- a/stylecop.json
+++ b/stylecop.json
@@ -29,7 +29,7 @@
         "readonly"
       ],
       "systemUsingDirectivesFirst": true,
-      "usingDirectivesPlacement": "insideNamespace"
+      "usingDirectivesPlacement": "outsideNamespace"
     },
     "readabilityRules": {},
     "spacingRules": {}

--- a/tests/LondonTravel.Site.Tests/BrowserFixture.cs
+++ b/tests/LondonTravel.Site.Tests/BrowserFixture.cs
@@ -1,16 +1,16 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Globalization;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using Xunit.Abstractions;
+
 namespace MartinCostello.LondonTravel.Site
 {
-    using System;
-    using System.Globalization;
-    using System.IO;
-    using System.Runtime.CompilerServices;
-    using System.Threading.Tasks;
-    using Microsoft.Playwright;
-    using Xunit.Abstractions;
-
     public class BrowserFixture
     {
         public BrowserFixture(ITestOutputHelper outputHelper)

--- a/tests/LondonTravel.Site.Tests/BrowserTest.cs
+++ b/tests/LondonTravel.Site.Tests/BrowserTest.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Pages;
+using Xunit.Abstractions;
+
 namespace MartinCostello.LondonTravel.Site
 {
-    using System;
-    using System.Runtime.CompilerServices;
-    using System.Threading.Tasks;
-    using Pages;
-    using Xunit.Abstractions;
-
     /// <summary>
     /// The base class for browser tests.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/BrowsersTestData.cs
+++ b/tests/LondonTravel.Site.Tests/BrowsersTestData.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
 namespace MartinCostello.LondonTravel.Site
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-
     public sealed class BrowsersTestData : IEnumerable<object[]>
     {
         public IEnumerator<object[]> GetEnumerator()

--- a/tests/LondonTravel.Site.Tests/Controllers/AlexaControllerTests.cs
+++ b/tests/LondonTravel.Site.Tests/Controllers/AlexaControllerTests.cs
@@ -1,26 +1,26 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+using MartinCostello.LondonTravel.Site.Options;
+using MartinCostello.LondonTravel.Site.Telemetry;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Security.Claims;
-    using System.Threading.Tasks;
-    using Identity;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Identity;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.AspNetCore.Mvc.Controllers;
-    using Microsoft.AspNetCore.Routing;
-    using Microsoft.Extensions.Logging;
-    using Moq;
-    using Options;
-    using Shouldly;
-    using Telemetry;
-    using Xunit;
-
     /// <summary>
     /// A class containing tests for the <see cref="AlexaController"/> class. This class cannot be inherited.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Controllers/ApiControllerTests.cs
+++ b/tests/LondonTravel.Site.Tests/Controllers/ApiControllerTests.cs
@@ -1,29 +1,29 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+using MartinCostello.LondonTravel.Site.Models;
+using MartinCostello.LondonTravel.Site.Services;
+using MartinCostello.LondonTravel.Site.Services.Data;
+using MartinCostello.LondonTravel.Site.Telemetry;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Linq.Expressions;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Identity;
-    using MartinCostello.LondonTravel.Site.Services;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.AspNetCore.Mvc.Controllers;
-    using Microsoft.AspNetCore.Routing;
-    using Microsoft.Extensions.Caching.Memory;
-    using Microsoft.Extensions.Logging;
-    using Models;
-    using Moq;
-    using Services.Data;
-    using Shouldly;
-    using Telemetry;
-    using Xunit;
-
     /// <summary>
     /// A class containing tests for the <see cref="ApiController"/> class. This class cannot be inherited.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Controllers/RegisterControllerTests.cs
+++ b/tests/LondonTravel.Site.Tests/Controllers/RegisterControllerTests.cs
@@ -1,20 +1,21 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Models;
+using MartinCostello.LondonTravel.Site.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using Shouldly;
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.Controllers
 {
-    using System;
-    using System.Security.Claims;
-    using System.Threading.Tasks;
-    using MartinCostello.LondonTravel.Site.Models;
-    using MartinCostello.LondonTravel.Site.Services;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.AspNetCore.Mvc.Controllers;
-    using Microsoft.AspNetCore.Routing;
-    using Moq;
-    using Shouldly;
-    using Xunit;
-
     /// <summary>
     /// A class containing tests for the <see cref="RegisterController"/> class. This class cannot be inherited.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/EndToEnd/ApiTests.cs
+++ b/tests/LondonTravel.Site.Tests/EndToEnd/ApiTests.cs
@@ -1,16 +1,16 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.EndToEnd
 {
-    using System;
-    using System.Net;
-    using System.Net.Http.Headers;
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Http;
-    using Shouldly;
-    using Xunit;
-
     [Collection(WebsiteCollection.Name)]
     [Trait("Category", "EndToEnd")]
     public class ApiTests

--- a/tests/LondonTravel.Site.Tests/EndToEnd/BrowserEndToEndTest.cs
+++ b/tests/LondonTravel.Site.Tests/EndToEnd/BrowserEndToEndTest.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
 namespace MartinCostello.LondonTravel.Site.EndToEnd
 {
-    using System;
-    using Xunit;
-    using Xunit.Abstractions;
-
     /// <summary>
     /// The base class for end-to-end tests.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/EndToEnd/ResourceTests.cs
+++ b/tests/LondonTravel.Site.Tests/EndToEnd/ResourceTests.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Net;
+using System.Net.Mime;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.EndToEnd
 {
-    using System.Net;
-    using System.Net.Mime;
-    using System.Threading.Tasks;
-    using Shouldly;
-    using Xunit;
-
     [Collection(WebsiteCollection.Name)]
     [Trait("Category", "EndToEnd")]
     public class ResourceTests

--- a/tests/LondonTravel.Site.Tests/EndToEnd/SocialLoginTests.cs
+++ b/tests/LondonTravel.Site.Tests/EndToEnd/SocialLoginTests.cs
@@ -1,16 +1,16 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Pages;
+using Microsoft.Playwright;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
 namespace MartinCostello.LondonTravel.Site.EndToEnd
 {
-    using System;
-    using System.Threading.Tasks;
-    using MartinCostello.LondonTravel.Site.Pages;
-    using Microsoft.Playwright;
-    using Shouldly;
-    using Xunit;
-    using Xunit.Abstractions;
-
     public class SocialLoginTests : BrowserEndToEndTest
     {
         public SocialLoginTests(WebsiteFixture fixture, ITestOutputHelper outputHelper)

--- a/tests/LondonTravel.Site.Tests/EndToEnd/WebsiteCollection.cs
+++ b/tests/LondonTravel.Site.Tests/EndToEnd/WebsiteCollection.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.EndToEnd
 {
-    using Xunit;
-
     /// <summary>
     /// A class representing the collection fixture for an HTTP server. This class cannot be inherited.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/EndToEnd/WebsiteFixture.cs
+++ b/tests/LondonTravel.Site.Tests/EndToEnd/WebsiteFixture.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.EndToEnd
 {
-    using System;
-    using System.Net.Http;
-    using System.Net.Http.Headers;
-    using Xunit;
-
     public class WebsiteFixture
     {
         private const string WebsiteUrl = "WEBSITE_URL";

--- a/tests/LondonTravel.Site.Tests/Extensions/ClaimsPrincipalExtensionsTests.cs
+++ b/tests/LondonTravel.Site.Tests/Extensions/ClaimsPrincipalExtensionsTests.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Security.Claims;
+using Shouldly;
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using System;
-    using System.Security.Claims;
-    using Shouldly;
-    using Xunit;
-
     /// <summary>
     /// A class containing unit tests for the <see cref="ClaimsPrincipalExtensions"/> class.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Extensions/IHostExtensions.cs
+++ b/tests/LondonTravel.Site.Tests/Extensions/IHostExtensions.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
 namespace MartinCostello.LondonTravel.Site.Extensions
 {
-    using System;
-    using System.Linq;
-    using Microsoft.AspNetCore.Hosting.Server;
-    using Microsoft.AspNetCore.Hosting.Server.Features;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
-
     internal static class IHostExtensions
     {
         public static Uri GetAddress(this IHost host)

--- a/tests/LondonTravel.Site.Tests/HttpResponseMessageExtensions.cs
+++ b/tests/LondonTravel.Site.Tests/HttpResponseMessageExtensions.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Net.Http;
+using System.Net.Mime;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Shouldly;
+
 namespace MartinCostello.LondonTravel.Site
 {
-    using System.Net.Http;
-    using System.Net.Mime;
-    using System.Text.Json;
-    using System.Threading.Tasks;
-    using Shouldly;
-
     public static class HttpResponseMessageExtensions
     {
         public static async Task<JsonDocument> ReadAsJsonDocumentAsync(this HttpResponseMessage response)

--- a/tests/LondonTravel.Site.Tests/Identity/AuthenticationBuilderExtensionsTests.cs
+++ b/tests/LondonTravel.Site.Tests/Identity/AuthenticationBuilderExtensionsTests.cs
@@ -1,19 +1,19 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AspNet.Security.OAuth.Amazon;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.Identity
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using AspNet.Security.OAuth.Amazon;
-    using Microsoft.AspNetCore.Authentication;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.Logging;
-    using Moq;
-    using Shouldly;
-    using Xunit;
-
     public static class AuthenticationBuilderExtensionsTests
     {
         [Theory]

--- a/tests/LondonTravel.Site.Tests/Identity/LondonTravelRoleTests.cs
+++ b/tests/LondonTravel.Site.Tests/Identity/LondonTravelRoleTests.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Security.Claims;
+using Shouldly;
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.Identity
 {
-    using System;
-    using System.Security.Claims;
-    using Shouldly;
-    using Xunit;
-
     public static class LondonTravelRoleTests
     {
         [Fact]

--- a/tests/LondonTravel.Site.Tests/Identity/UserStoreTests.cs
+++ b/tests/LondonTravel.Site.Tests/Identity/UserStoreTests.cs
@@ -1,19 +1,19 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Services.Data;
+using Microsoft.AspNetCore.Identity;
+using Moq;
+using Shouldly;
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.Identity
 {
-    using System;
-    using System.Linq;
-    using System.Security.Claims;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using MartinCostello.LondonTravel.Site.Services.Data;
-    using Microsoft.AspNetCore.Identity;
-    using Moq;
-    using Shouldly;
-    using Xunit;
-
     public static class UserStoreTests
     {
         [Fact]

--- a/tests/LondonTravel.Site.Tests/Integration/AccountTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/AccountTests.cs
@@ -1,22 +1,22 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Mime;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using System;
-    using System.Net;
-    using System.Net.Http;
-    using System.Net.Http.Headers;
-    using System.Net.Mime;
-    using System.Text.Json;
-    using System.Threading.Tasks;
-    using MartinCostello.LondonTravel.Site.Identity;
-    using Microsoft.AspNetCore.Identity;
-    using Microsoft.Extensions.DependencyInjection;
-    using Shouldly;
-    using Xunit;
-    using Xunit.Abstractions;
-
     /// <summary>
     /// A class containing tests for user accounts.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Integration/AlexaTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/AlexaTests.cs
@@ -1,22 +1,22 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Pages;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Net;
-    using System.Net.Http.Headers;
-    using System.Text.Json;
-    using System.Threading.Tasks;
-    using MartinCostello.LondonTravel.Site.Pages;
-    using Microsoft.AspNetCore.WebUtilities;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Primitives;
-    using Shouldly;
-    using Xunit;
-    using Xunit.Abstractions;
-
     /// <summary>
     /// A class containing tests for the integration with Alexa.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Integration/ApiTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/ApiTests.cs
@@ -1,16 +1,16 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using System;
-    using System.Net;
-    using System.Net.Http.Headers;
-    using System.Threading.Tasks;
-    using Shouldly;
-    using Xunit;
-    using Xunit.Abstractions;
-
     /// <summary>
     /// A class containing tests for the API.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Integration/AuthenticationTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/AuthenticationTests.cs
@@ -1,16 +1,16 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Pages;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using Microsoft.Extensions.DependencyInjection;
-    using Pages;
-    using Shouldly;
-    using Xunit;
-    using Xunit.Abstractions;
-
     /// <summary>
     /// A class containing tests for authentication providers in the website.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Integration/BrowserIntegrationTest.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/BrowserIntegrationTest.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Threading.Tasks;
+using JustEat.HttpClientInterception;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using System;
-    using System.Threading.Tasks;
-    using JustEat.HttpClientInterception;
-    using Microsoft.Extensions.Logging;
-    using Xunit;
-    using Xunit.Abstractions;
-
     /// <summary>
     /// The base class for browser tests.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Integration/HttpRequestInterceptionFilter.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/HttpRequestInterceptionFilter.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using JustEat.HttpClientInterception;
+using Microsoft.Extensions.Http;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using System;
-    using JustEat.HttpClientInterception;
-    using Microsoft.Extensions.Http;
-
     /// <summary>
     /// A class representing an <see cref="IHttpMessageHandlerBuilderFilter"/> that configures
     /// HTTP request interception with HttpClientFactory. This class cannot be inherited.

--- a/tests/LondonTravel.Site.Tests/Integration/HttpServerCollection.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/HttpServerCollection.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using Xunit;
-
     /// <summary>
     /// A class representing the collection fixture for an HTTP server. This class cannot be inherited.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Integration/HttpServerFixture.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/HttpServerFixture.cs
@@ -1,22 +1,22 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using JustEat.HttpClientInterception;
+using MartinCostello.LondonTravel.Site.Extensions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Net.Http;
-    using System.Security.Cryptography.X509Certificates;
-    using System.Threading.Tasks;
-    using JustEat.HttpClientInterception;
-    using MartinCostello.LondonTravel.Site.Extensions;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
-    using Xunit;
-
     /// <summary>
     /// A test fixture representing an HTTP server hosting the application. This class cannot be inherited.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Integration/InMemoryDocumentStore.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/InMemoryDocumentStore.cs
@@ -1,19 +1,19 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+using MartinCostello.LondonTravel.Site.Options;
+using MartinCostello.LondonTravel.Site.Services.Data;
+using Microsoft.Azure.Cosmos;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Linq.Expressions;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using MartinCostello.LondonTravel.Site.Identity;
-    using MartinCostello.LondonTravel.Site.Options;
-    using MartinCostello.LondonTravel.Site.Services.Data;
-    using Microsoft.Azure.Cosmos;
-
     /// <summary>
     /// A class representing an in-memory document store. This class cannot be inherited.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Integration/IntegrationTest.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/IntegrationTest.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using System;
-    using Xunit;
-    using Xunit.Abstractions;
-
     /// <summary>
     /// The base class for integration tests.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Integration/PreferencesTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/PreferencesTests.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Pages;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using Microsoft.Extensions.DependencyInjection;
-    using Pages;
-    using Shouldly;
-    using Xunit;
-    using Xunit.Abstractions;
-
     /// <summary>
     /// A class containing tests for user preferences in the website.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Integration/RemoteAuthorizationEventsFilter.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/RemoteAuthorizationEventsFilter.cs
@@ -1,20 +1,20 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Specialized;
+using System.Threading.Tasks;
+using System.Web;
+using MartinCostello.LondonTravel.Site.Extensions;
+using MartinCostello.LondonTravel.Site.Identity;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using System;
-    using System.Collections.Specialized;
-    using System.Threading.Tasks;
-    using System.Web;
-    using MartinCostello.LondonTravel.Site.Extensions;
-    using MartinCostello.LondonTravel.Site.Identity;
-    using Microsoft.AspNetCore.Authentication;
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
-
     /// <summary>
     /// A class representing a <see cref="IStartupFilter"/> that allows the tests to redirect external
     /// authentication provider requests back into the application. This class cannot be inherited.

--- a/tests/LondonTravel.Site.Tests/Integration/ResourceTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/ResourceTests.cs
@@ -1,19 +1,19 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Mime;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using System;
-    using System.Linq;
-    using System.Net;
-    using System.Net.Http;
-    using System.Net.Mime;
-    using System.Text.Json;
-    using System.Threading.Tasks;
-    using Shouldly;
-    using Xunit;
-    using Xunit.Abstractions;
-
     /// <summary>
     /// A class containing tests for loading resources in the website.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Integration/SiteMapTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/SiteMapTests.cs
@@ -1,18 +1,18 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Globalization;
+using System.Net;
+using System.Net.Mime;
+using System.Threading.Tasks;
+using System.Xml;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using System;
-    using System.Globalization;
-    using System.Net;
-    using System.Net.Mime;
-    using System.Threading.Tasks;
-    using System.Xml;
-    using Shouldly;
-    using Xunit;
-    using Xunit.Abstractions;
-
     /// <summary>
     /// A class containing tests for the site map.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Integration/TestServerCollection.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/TestServerCollection.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using Xunit;
-
     /// <summary>
     /// A class representing the collection fixture for a test server. This class cannot be inherited.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Integration/TestServerFixture.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/TestServerFixture.cs
@@ -1,25 +1,25 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using AspNet.Security.OAuth.Apple;
+using JustEat.HttpClientInterception;
+using MartinCostello.Logging.XUnit;
+using MartinCostello.LondonTravel.Site.Services.Data;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
 namespace MartinCostello.LondonTravel.Site.Integration
 {
-    using System;
-    using System.IO;
-    using System.Linq;
-    using System.Reflection;
-    using AspNet.Security.OAuth.Apple;
-    using JustEat.HttpClientInterception;
-    using MartinCostello.Logging.XUnit;
-    using MartinCostello.LondonTravel.Site.Services.Data;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.Mvc.Testing;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
-    using Microsoft.Extensions.Http;
-    using Microsoft.Extensions.Logging;
-    using Xunit.Abstractions;
-
     /// <summary>
     /// A class representing a factory for creating instances of the application.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/JsonElementExtensions.cs
+++ b/tests/LondonTravel.Site.Tests/JsonElementExtensions.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Linq;
+using System.Text.Json;
+
 namespace MartinCostello.LondonTravel.Site
 {
-    using System.Linq;
-    using System.Text.Json;
-
     internal static class JsonElementExtensions
     {
         internal static int GetInt32(this JsonElement element, string propertyName)

--- a/tests/LondonTravel.Site.Tests/Models/MetaModelTests.cs
+++ b/tests/LondonTravel.Site.Tests/Models/MetaModelTests.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using MartinCostello.LondonTravel.Site.Options;
+using Shouldly;
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.Models
 {
-    using MartinCostello.LondonTravel.Site.Options;
-    using Shouldly;
-    using Xunit;
-
     /// <summary>
     /// A class containing unit tests for the <see cref="MetaModel"/> class.
     /// </summary>

--- a/tests/LondonTravel.Site.Tests/Pages/ApplicationNavigator.cs
+++ b/tests/LondonTravel.Site.Tests/Pages/ApplicationNavigator.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
 namespace MartinCostello.LondonTravel.Site.Pages
 {
-    using System;
-    using System.Threading.Tasks;
-    using Microsoft.Playwright;
-
     public class ApplicationNavigator
     {
         public ApplicationNavigator(Uri baseUri, IPage page)

--- a/tests/LondonTravel.Site.Tests/Pages/DeleteModal.cs
+++ b/tests/LondonTravel.Site.Tests/Pages/DeleteModal.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Threading.Tasks;
+
 namespace MartinCostello.LondonTravel.Site.Pages
 {
-    using System.Threading.Tasks;
-
     public sealed class DeleteModal : ModalBase
     {
         public DeleteModal(ApplicationNavigator navigator)

--- a/tests/LondonTravel.Site.Tests/Pages/HomePage.cs
+++ b/tests/LondonTravel.Site.Tests/Pages/HomePage.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace MartinCostello.LondonTravel.Site.Pages
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
-
     public sealed class HomePage : PageBase
     {
         public HomePage(ApplicationNavigator navigator)

--- a/tests/LondonTravel.Site.Tests/Pages/LinePreference.cs
+++ b/tests/LondonTravel.Site.Tests/Pages/LinePreference.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
 namespace MartinCostello.LondonTravel.Site.Pages
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using Microsoft.Playwright;
-
     public sealed class LinePreference
     {
         internal LinePreference(IElementHandle element)

--- a/tests/LondonTravel.Site.Tests/Pages/LinkedAccount.cs
+++ b/tests/LondonTravel.Site.Tests/Pages/LinkedAccount.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
 namespace MartinCostello.LondonTravel.Site.Pages
 {
-    using System.Threading.Tasks;
-    using Microsoft.Playwright;
-
     public sealed class LinkedAccount
     {
         internal LinkedAccount(ApplicationNavigator navigator, IElementHandle element)

--- a/tests/LondonTravel.Site.Tests/Pages/ManagePage.cs
+++ b/tests/LondonTravel.Site.Tests/Pages/ManagePage.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
 namespace MartinCostello.LondonTravel.Site.Pages
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using Microsoft.Playwright;
-
     public sealed class ManagePage : PageBase
     {
         public ManagePage(ApplicationNavigator navigator)

--- a/tests/LondonTravel.Site.Tests/Pages/ModalBase.cs
+++ b/tests/LondonTravel.Site.Tests/Pages/ModalBase.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
 namespace MartinCostello.LondonTravel.Site.Pages
 {
-    using System.Threading.Tasks;
-    using Microsoft.Playwright;
-
     public abstract class ModalBase
     {
         protected ModalBase(string name, ApplicationNavigator navigator)

--- a/tests/LondonTravel.Site.Tests/Pages/PageBase.cs
+++ b/tests/LondonTravel.Site.Tests/Pages/PageBase.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Threading.Tasks;
+
 namespace MartinCostello.LondonTravel.Site.Pages
 {
-    using System.Threading.Tasks;
-
     public abstract class PageBase
     {
         protected PageBase(ApplicationNavigator navigator)

--- a/tests/LondonTravel.Site.Tests/Pages/PageBaseExtensions.cs
+++ b/tests/LondonTravel.Site.Tests/Pages/PageBaseExtensions.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Threading.Tasks;
+
 namespace MartinCostello.LondonTravel.Site.Pages
 {
-    using System.Threading.Tasks;
-
     public static class PageBaseExtensions
     {
         public static async Task<T> NavigateAsync<T>(this T page)

--- a/tests/LondonTravel.Site.Tests/Pages/RemoveAlexaLinkModal.cs
+++ b/tests/LondonTravel.Site.Tests/Pages/RemoveAlexaLinkModal.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Threading.Tasks;
+
 namespace MartinCostello.LondonTravel.Site.Pages
 {
-    using System.Threading.Tasks;
-
     public sealed class RemoveAlexaLinkModal : ModalBase
     {
         public RemoveAlexaLinkModal(ApplicationNavigator navigator)

--- a/tests/LondonTravel.Site.Tests/Pages/SignInPage.cs
+++ b/tests/LondonTravel.Site.Tests/Pages/SignInPage.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Threading.Tasks;
+
 namespace MartinCostello.LondonTravel.Site.Pages
 {
-    using System.Threading.Tasks;
-
     public sealed class SignInPage : PageBase
     {
         public SignInPage(ApplicationNavigator navigator)

--- a/tests/LondonTravel.Site.Tests/Services/Data/DocumentHelpersTests.cs
+++ b/tests/LondonTravel.Site.Tests/Services/Data/DocumentHelpersTests.cs
@@ -1,19 +1,19 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Net.Http;
+using MartinCostello.LondonTravel.Site.Options;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shouldly;
+using Xunit;
+using Option = Microsoft.Extensions.Options.Options;
+
 namespace MartinCostello.LondonTravel.Site.Services.Data
 {
-    using System;
-    using System.Net.Http;
-    using MartinCostello.LondonTravel.Site.Options;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Azure.Cosmos;
-    using Microsoft.Extensions.DependencyInjection;
-    using Moq;
-    using Shouldly;
-    using Xunit;
-    using Options = Microsoft.Extensions.Options.Options;
-
     public static class DocumentHelpersTests
     {
         [Fact]
@@ -159,7 +159,7 @@ namespace MartinCostello.LondonTravel.Site.Services.Data
 
             var services = new ServiceCollection()
                 .AddHttpClient()
-                .AddSingleton(Options.Create(new JsonOptions()))
+                .AddSingleton(Option.Create(new JsonOptions()))
                 .AddSingleton(options);
 
             using var serviceProvider = services.BuildServiceProvider();
@@ -185,7 +185,7 @@ namespace MartinCostello.LondonTravel.Site.Services.Data
 
             var services = new ServiceCollection()
                 .AddHttpClient()
-                .AddSingleton(Options.Create(new JsonOptions()))
+                .AddSingleton(Option.Create(new JsonOptions()))
                 .AddSingleton(options);
 
             using var serviceProvider = services.BuildServiceProvider();

--- a/tests/LondonTravel.Site.Tests/Services/Data/SystemTextJsonCosmosSerializerTests.cs
+++ b/tests/LondonTravel.Site.Tests/Services/Data/SystemTextJsonCosmosSerializerTests.cs
@@ -1,16 +1,16 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MartinCostello.LondonTravel.Site.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.Services.Data
 {
-    using System;
-    using System.Text.Json;
-    using System.Threading.Tasks;
-    using MartinCostello.LondonTravel.Site.Identity;
-    using Microsoft.AspNetCore.Mvc;
-    using Shouldly;
-    using Xunit;
-
     public static class SystemTextJsonCosmosSerializerTests
     {
         [Fact]

--- a/tests/LondonTravel.Site.Tests/Services/Tfl/TflServiceTests.cs
+++ b/tests/LondonTravel.Site.Tests/Services/Tfl/TflServiceTests.cs
@@ -1,19 +1,19 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using JustEat.HttpClientInterception;
+using MartinCostello.LondonTravel.Site.Options;
+using Microsoft.Extensions.Caching.Memory;
+using Refit;
+using Xunit;
+
 namespace MartinCostello.LondonTravel.Site.Services.Tfl
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Net.Http;
-    using System.Threading.Tasks;
-    using JustEat.HttpClientInterception;
-    using MartinCostello.LondonTravel.Site.Options;
-    using Microsoft.Extensions.Caching.Memory;
-    using Refit;
-    using Xunit;
-
     public sealed class TflServiceTests : IDisposable
     {
         private readonly IMemoryCache _cache;

--- a/tests/LondonTravel.Site.Tests/TaskExtensions.cs
+++ b/tests/LondonTravel.Site.Tests/TaskExtensions.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Threading.Tasks;
+using Shouldly;
+
 namespace MartinCostello.LondonTravel.Site
 {
-    using System;
-    using System.Threading.Tasks;
-    using Shouldly;
-
     internal static class TaskExtensions
     {
         public static async Task<T2> ThenAsync<T1, T2>(this Task<T1> value, Func<T1, Task<T2>> continuation)


### PR DESCRIPTION
Move the using statements outside of the namespace do that global usings can be added in #901.
