### PR TITLE
Use DangerousAcceptAnyServerCertificateValidator

### DIFF
--- a/tests/LondonTravel.Site.Tests/Integration/HttpServerFixture.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/HttpServerFixture.cs
@@ -85,7 +85,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
             if (ClientOptions.BaseAddress.IsLoopback &&
                 string.Equals(ClientOptions.BaseAddress.Scheme, "https", StringComparison.OrdinalIgnoreCase))
             {
-                handler.ServerCertificateCustomValidationCallback = (request, cert, chain, errors) => true;
+                handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
             }
 
             var client = new HttpClient(handler, disposeHandler: true);


### PR DESCRIPTION
Use the `HttpClientHandler.DangerousAcceptAnyServerCertificateValidator` property instead of defining a custom lambda.
