### PR TITLE
Simplify tests

### DIFF
--- a/tests/LondonTravel.Site.Tests/Integration/TestServerFixture.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/TestServerFixture.cs
@@ -3,14 +3,13 @@
 
 using System;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 using AspNet.Security.OAuth.Apple;
 using JustEat.HttpClientInterception;
 using MartinCostello.Logging.XUnit;
 using MartinCostello.LondonTravel.Site.Services.Data;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -101,24 +100,7 @@ namespace MartinCostello.LondonTravel.Site.Integration
 
             builder.ConfigureAppConfiguration(ConfigureTests)
                    .ConfigureLogging((loggingBuilder) => loggingBuilder.ClearProviders().AddXUnit(this))
-                   .UseContentRoot(GetApplicationContentRootPath());
-        }
-
-        /// <summary>
-        /// Gets the content root path to use for the application.
-        /// </summary>
-        /// <returns>
-        /// The content root path to use for the application.
-        /// </returns>
-        protected string GetApplicationContentRootPath()
-        {
-            var attribute = GetTestAssemblies()
-                .SelectMany((p) => p.GetCustomAttributes<WebApplicationFactoryContentRootAttribute>())
-                .Where((p) => string.Equals(p.Key, "LondonTravel.Site", StringComparison.OrdinalIgnoreCase))
-                .OrderBy((p) => p.Priority)
-                .First();
-
-            return attribute.ContentRootPath;
+                   .UseSolutionRelativeContentRoot(Path.Combine("src", "LondonTravel.Site"));
         }
 
         private void ConfigureTests(IConfigurationBuilder builder)


### PR DESCRIPTION
Simplify the tests by using `UseSolutionRelativeContentRoot()`.
