### PR TITLE
Bug fixes

### DIFF
--- a/src/LondonTravel.Site/AlexaModule.cs
+++ b/src/LondonTravel.Site/AlexaModule.cs
@@ -17,16 +17,14 @@ public static class AlexaModule
             [FromQuery(Name = "response_type")] string? responseType,
             [FromQuery(Name = "redirect_uri")] BindableUri? redirectUri,
             ClaimsPrincipal user,
-            AlexaService service,
-            CancellationToken cancellationToken) =>
+            AlexaService service) =>
         {
             return await service.AuthorizeSkillAsync(
                 state,
                 clientId,
                 responseType,
                 redirectUri,
-                user,
-                cancellationToken);
+                user);
         })
         .ExcludeFromDescription()
         .RequireAuthorization();

--- a/src/LondonTravel.Site/Controllers/ManageController.cs
+++ b/src/LondonTravel.Site/Controllers/ManageController.cs
@@ -50,7 +50,6 @@ public class ManageController : Controller
         var userLogins = (await _userManager.GetLoginsAsync(user))
             .OrderBy((p) => p.ProviderDisplayName)
             .ThenBy((p) => p.LoginProvider)
-            .ThenBy((p) => p.ProviderKey)
             .ToList();
 
         var otherLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync())

--- a/src/LondonTravel.Site/Controllers/ManageController.cs
+++ b/src/LondonTravel.Site/Controllers/ManageController.cs
@@ -47,10 +47,7 @@ public class ManageController : Controller
             return View("Error");
         }
 
-        var userLogins = (await _userManager.GetLoginsAsync(user))
-            .OrderBy((p) => p.ProviderDisplayName)
-            .ThenBy((p) => p.LoginProvider)
-            .ToList();
+        var userLogins = await _userManager.GetLoginsAsync(user);
 
         var otherLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync())
             .Where((p) => userLogins.All((r) => p.Name != r.LoginProvider))
@@ -65,6 +62,11 @@ public class ManageController : Controller
                 login.ProviderDisplayName = login.LoginProvider;
             }
         }
+
+        userLogins = userLogins
+            .OrderBy((p) => p.ProviderDisplayName)
+            .ThenBy((p) => p.LoginProvider)
+            .ToList();
 
         var model = new ManageViewModel()
         {

--- a/src/LondonTravel.Site/Pages/Home/Index.cshtml.cs
+++ b/src/LondonTravel.Site/Pages/Home/Index.cshtml.cs
@@ -72,6 +72,11 @@ public class Index : PageModel
 
     public async Task OnGet(string? updateSuccess = null)
     {
+        if (User.Identity?.IsAuthenticated == false)
+        {
+            return;
+        }
+
         var user = await _userManager.GetUserAsync(User);
 
         if (user == null)

--- a/src/LondonTravel.Site/Services/AlexaService.cs
+++ b/src/LondonTravel.Site/Services/AlexaService.cs
@@ -49,8 +49,7 @@ public sealed class AlexaService
         string? clientId,
         string? responseType,
         Uri? redirectUri,
-        ClaimsPrincipal user,
-        CancellationToken cancellationToken)
+        ClaimsPrincipal user)
     {
         if (_options?.IsLinkingEnabled != true)
         {

--- a/src/LondonTravel.Site/gulpfile.js
+++ b/src/LondonTravel.Site/gulpfile.js
@@ -134,11 +134,11 @@ gulp.task("test:js", gulp.series("test:js:karma"));
 gulp.task("test", gulp.series("test:js"));
 
 gulp.task("watch", function () {
-    getBundles(regex.js).forEach(function (bundle) {
-        gulp.watch(bundle.inputFiles, ["min:js"]);
-    });
     getBundles(regex.css).forEach(function (bundle) {
-        gulp.watch(bundle.inputFiles, ["min:css"]);
+        gulp.watch(bundle.inputFiles, gulp.series("min:css"));
+    });
+    getBundles(regex.js).forEach(function (bundle) {
+        gulp.watch(bundle.inputFiles, gulp.series("min:js"));
     });
 });
 

--- a/tests/LondonTravel.Site.Tests/Services/AlexaServiceTests.cs
+++ b/tests/LondonTravel.Site.Tests/Services/AlexaServiceTests.cs
@@ -59,8 +59,7 @@ public class AlexaServiceTests
             clientId,
             responseType,
             redirectUri,
-            new ClaimsPrincipal(),
-            CancellationToken.None);
+            new ClaimsPrincipal());
 
         // Assert
         actual.ShouldNotBeNull();
@@ -90,8 +89,7 @@ public class AlexaServiceTests
             clientId,
             responseType,
             redirectUri,
-            new ClaimsPrincipal(),
-            CancellationToken.None);
+            new ClaimsPrincipal());
 
         // Assert
         await AssertRedirect(
@@ -117,8 +115,7 @@ public class AlexaServiceTests
             clientId,
             responseType,
             redirectUri,
-            new ClaimsPrincipal(),
-            CancellationToken.None);
+            new ClaimsPrincipal());
 
         // Assert
         await AssertRedirect(
@@ -144,8 +141,7 @@ public class AlexaServiceTests
             clientId,
             responseType,
             redirectUri,
-            new ClaimsPrincipal(),
-            CancellationToken.None);
+            new ClaimsPrincipal());
 
         // Assert
         await AssertRedirect(
@@ -171,8 +167,7 @@ public class AlexaServiceTests
             clientId,
             responseType,
             redirectUri,
-            new ClaimsPrincipal(),
-            CancellationToken.None);
+            new ClaimsPrincipal());
 
         // Assert
         await AssertRedirect(
@@ -203,8 +198,7 @@ public class AlexaServiceTests
             clientId,
             responseType,
             redirectUri,
-            new ClaimsPrincipal(),
-            CancellationToken.None);
+            new ClaimsPrincipal());
 
         // Assert
         actual.ShouldNotBeNull();
@@ -233,8 +227,7 @@ public class AlexaServiceTests
             clientId,
             responseType,
             redirectUri,
-            new ClaimsPrincipal(),
-            CancellationToken.None);
+            new ClaimsPrincipal());
 
         // Assert
         await AssertRedirect(
@@ -264,8 +257,7 @@ public class AlexaServiceTests
             clientId,
             responseType,
             redirectUri,
-            new ClaimsPrincipal(),
-            CancellationToken.None);
+            new ClaimsPrincipal());
 
         // Assert
         await AssertRedirect(
@@ -301,8 +293,7 @@ public class AlexaServiceTests
             clientId,
             responseType,
             redirectUri,
-            new ClaimsPrincipal(),
-            CancellationToken.None);
+            new ClaimsPrincipal());
 
         // Assert
         actual.ShouldNotBeNull();


### PR DESCRIPTION
* Fix the gulp watch task not actually working/running.
* Do not sort the external logins by provider key, as that's the user's Id in that system, not the provider's name. (see #1007)
* Don't log an error if the user cannot be found if it is only because there is no user logged in.
* Remove unused method parameter.
