### PR TITLE
Bump NodaTimeVersion from 3.0.9 to 3.0.10

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AspNetSecurityOAuthVersion>6.0.4</AspNetSecurityOAuthVersion>
     <MicrosoftAspNetCoreAuthenticationVersion>6.0.3</MicrosoftAspNetCoreAuthenticationVersion>
-    <NodaTimeVersion>3.0.9</NodaTimeVersion>
+    <NodaTimeVersion>3.0.10</NodaTimeVersion>
     <SwashbuckleAspNetCoreVersion>6.3.0</SwashbuckleAspNetCoreVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Reverts martincostello/alexa-london-travel-site#1280 to bump NodaTime back to 3.0.10.