### PR TITLE
Fix incorrect data protection storage

### DIFF
--- a/src/LondonTravel.Site/Program.cs
+++ b/src/LondonTravel.Site/Program.cs
@@ -49,7 +49,7 @@ string connectionString = builder.Configuration.AzureStorageConnectionString();
 
 if (!string.IsNullOrWhiteSpace(connectionString))
 {
-    string relativePath = $"/london-travel/{environment}/keys.xml";
+    string relativePath = $"london-travel/{environment}/keys.xml";
     dataProtection.PersistKeysToAzureBlobStorage(
         connectionString,
         "data-protection",


### PR DESCRIPTION
Remove leading slash, as it puts the keys in the wrong place (which seemed to happen in September 2020).
