### PR TITLE
Add end-to-end test concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,8 @@ jobs:
   test-dev:
     name: test-dev
     needs: deploy-dev
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
+    concurrency: development_environment
 
     steps:
 
@@ -187,7 +188,8 @@ jobs:
   test-prod:
     name: test-prod
     needs: deploy-prod
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
+    concurrency: production_environment
 
     steps:
 


### PR DESCRIPTION
- Use the same concurrency for deployment as the tests to try and prevent subsequent deployments running while the tests from the previous deployment are still running.
- Run end-to-end tests on Linux.
