### PR TITLE
Update security.txt for RFC 9116

### DIFF
--- a/src/LondonTravel.Site/wwwroot/.well-known/security.txt
+++ b/src/LondonTravel.Site/wwwroot/.well-known/security.txt
@@ -1,3 +1,20 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+Canonical: https://londontravel.martincostello.com/.well-known/security.txt
 Contact: https://twitter.com/martin_costello
 Contact: https://keybase.io/encrypt#martincostello
 Encryption: https://londontravel.martincostello.com/pgp-key.txt
+Preferred-Languages: en
+-----BEGIN PGP SIGNATURE-----
+Version: Keybase OpenPGP v2.1.13
+Comment: https://keybase.io/crypto
+
+wsBcBAABCgAGBQJialwHAAoJEOD/2oPRlHPPyVcH/RpTc7eeWFl920FISMdCvMmJ
+t3E/0k0HSpRzf+Ykc+8IMWVqYgs2hJDh9mMUNEiAkifN7xeYAQ2/+HyMqzu8DAIa
+/0YJhP2qHl1HXoz9LOWBBnThCf3bvo7Mfcga5p491pOC/czqBBWc9QnWNtFkGZR0
++ZMfQX85VUV120Rn0DrolPEvJHD3u7nw7HjqUjQT4PjTbEKUFSJ8Br0qMvThJM9Q
+AKXLY2bsBTMeM8gsdDAJ3W2evWDWlBJmLQugOKFdhkcOfVPab6e3C5CzO3jOlKUg
+KsFocbDTv07AX6a36UHWl+suhxyZp+/I1Q9p1VyNi4WhfWphGEON+q3xTCr5LRc=
+=vnlc
+-----END PGP SIGNATURE-----

--- a/src/LondonTravel.Site/wwwroot/security.txt
+++ b/src/LondonTravel.Site/wwwroot/security.txt
@@ -1,3 +1,20 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+Canonical: https://londontravel.martincostello.com/.well-known/security.txt
 Contact: https://twitter.com/martin_costello
 Contact: https://keybase.io/encrypt#martincostello
 Encryption: https://londontravel.martincostello.com/pgp-key.txt
+Preferred-Languages: en
+-----BEGIN PGP SIGNATURE-----
+Version: Keybase OpenPGP v2.1.13
+Comment: https://keybase.io/crypto
+
+wsBcBAABCgAGBQJialwHAAoJEOD/2oPRlHPPyVcH/RpTc7eeWFl920FISMdCvMmJ
+t3E/0k0HSpRzf+Ykc+8IMWVqYgs2hJDh9mMUNEiAkifN7xeYAQ2/+HyMqzu8DAIa
+/0YJhP2qHl1HXoz9LOWBBnThCf3bvo7Mfcga5p491pOC/czqBBWc9QnWNtFkGZR0
++ZMfQX85VUV120Rn0DrolPEvJHD3u7nw7HjqUjQT4PjTbEKUFSJ8Br0qMvThJM9Q
+AKXLY2bsBTMeM8gsdDAJ3W2evWDWlBJmLQugOKFdhkcOfVPab6e3C5CzO3jOlKUg
+KsFocbDTv07AX6a36UHWl+suhxyZp+/I1Q9p1VyNi4WhfWphGEON+q3xTCr5LRc=
+=vnlc
+-----END PGP SIGNATURE-----


### PR DESCRIPTION
- Update the security.txt to conform with [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116).
- Add a Canonical and Preferred-Languages properties.
- Sign with the specified PGP key.
