### PR TITLE
Use one property for ASP.NET Core version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <AspNetSecurityOAuthVersion>6.0.6</AspNetSecurityOAuthVersion>
-    <MicrosoftAspNetCoreAuthenticationVersion>6.0.5</MicrosoftAspNetCoreAuthenticationVersion>
+    <MicrosoftAspNetCoreVersion>6.0.5</MicrosoftAspNetCoreVersion>
     <NodaTimeVersion>3.1.0</NodaTimeVersion>
     <SwashbuckleAspNetCoreVersion>6.3.1</SwashbuckleAspNetCoreVersion>
   </PropertyGroup>
@@ -18,15 +18,15 @@
     <PackageVersion Include="JustEat.HttpClientInterception" Version="3.1.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.2.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Facebook" Version="$(MicrosoftAspNetCoreAuthenticationVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="$(MicrosoftAspNetCoreAuthenticationVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="$(MicrosoftAspNetCoreAuthenticationVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Twitter" Version="$(MicrosoftAspNetCoreAuthenticationVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="6.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Facebook" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Twitter" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.27.0" />
     <PackageVersion Include="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.21452.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="6.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.21.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />


### PR DESCRIPTION
Use a single MSBuild property for the version of all packages built from the dotnet/aspnetcore repo.

This should reduce merge conflicts and make #1244 easier to keep up-to-date.
