### PR TITLE
Rename Application Insights setting

### DIFF
--- a/src/LondonTravel.Site/Extensions/IConfigurationExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/IConfigurationExtensions.cs
@@ -9,15 +9,15 @@ namespace MartinCostello.LondonTravel.Site.Extensions;
 public static class IConfigurationExtensions
 {
     /// <summary>
-    /// Gets the configured Application Insights instrumentation key.
+    /// Gets the configured Application Insights connection string.
     /// </summary>
     /// <param name="config">The <see cref="IConfiguration"/> to use.</param>
     /// <returns>
-    /// The configured Application Insights instrumentation key, if any.
+    /// The configured Application Insights connection string, if any.
     /// </returns>
-    public static string ApplicationInsightsKey(this IConfiguration config)
+    public static string ApplicationInsightsConnectionString(this IConfiguration config)
     {
-        return config?["ApplicationInsights:InstrumentationKey"] ?? string.Empty;
+        return config?["ApplicationInsights:ConnectionString"] ?? string.Empty;
     }
 
     /// <summary>

--- a/src/LondonTravel.Site/Extensions/ILoggingBuilderExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/ILoggingBuilderExtensions.cs
@@ -27,7 +27,7 @@ public static class ILoggingBuilderExtensions
             .Enrich.WithProperty("AzureEnvironment", context.Configuration.AzureEnvironment())
             .Enrich.WithProperty("Version", GitMetadata.Commit)
             .ReadFrom.Configuration(context.Configuration)
-            .WriteTo.ApplicationInsights(context.Configuration.ApplicationInsightsKey(), TelemetryConverter.Events);
+            .WriteTo.ApplicationInsights(context.Configuration.ApplicationInsightsConnectionString(), TelemetryConverter.Events);
 
         if (context.HostingEnvironment.IsDevelopment())
         {


### PR DESCRIPTION
Rename the setting to control Application Insights to reflect the changes in #1384.
