### PR TITLE
Upgrade to Bootstrap 5

### DIFF
--- a/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
@@ -80,7 +80,6 @@ public sealed class CustomHttpHeadersMiddleware
                 context.Response.Headers.Remove("Server");
                 context.Response.Headers.Remove("X-Powered-By");
 
-                context.Response.Headers.Add("Feature-Policy", "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'");
                 context.Response.Headers.Add("Permissions-Policy", "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()");
                 context.Response.Headers.Add("Referrer-Policy", "no-referrer-when-downgrade");
                 context.Response.Headers.Add("X-Content-Type-Options", "nosniff");

--- a/src/LondonTravel.Site/Pages/Account/Register.cshtml
+++ b/src/LondonTravel.Site/Pages/Account/Register.cshtml
@@ -12,11 +12,11 @@
             <p class="lead">
                 @SR.RegisterLead
             </p>
-            <blockquote>
+            <blockquote class="blockquote">
                 <p>
-                    <i>
+                    <em>
                         @SR.CommuteSkillInvocation
-                    </i>
+                    </em>
                 </p>
             </blockquote>
             <p>

--- a/src/LondonTravel.Site/Pages/Docs/Index.cshtml
+++ b/src/LondonTravel.Site/Pages/Docs/Index.cshtml
@@ -42,8 +42,8 @@
 }
 
 @section scripts {
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.52.2/swagger-ui-bundle.min.js" integrity="sha512-qXOa9fD8b1Tgte4I2PQPSYCv1mhkDtpnfWtHf4u4OL99IXhjkLu5VXSLy9NRLx4493Q9JWodS0UpUBymLlNbig==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.52.2/swagger-ui-standalone-preset.min.js" integrity="sha512-hyE4+47ZMZtFjzyevO7G2n6G29rlpCyu5D7h+5815+Z5bULKObhFHy8wPaepKw+AOZa6s0cGAy4+rc9mVQXN8g==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.12.0/swagger-ui-bundle.min.js" integrity="sha512-sKa8WOPosIBmesxJhYX/uL1lGNw10iyh2oRnsI0fwzj1WXd/EIonclHX7jYRAzfk3/UX77+Lxk8ZdAXSdS6GyA==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.12.0/swagger-ui-standalone-preset.min.js" integrity="sha512-J8kACzvV/aKXKxVubTCOG2tkPFR5GzZEvKwr9dNjlzWzKiVufmoGNTyZCbiJ74KNu0vvdGnlgkPHzCw5fnMuZg==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
     <environment names="Development">
         <script src="~/assets/js/site.swagger.js" asp-append-version="true" defer></script>
     </environment>
@@ -54,5 +54,5 @@
 
 @section stylesHead {
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" crossorigin="anonymous" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.52.2/swagger-ui.min.css" integrity="sha512-OzAczs3EC865hvaGNsO241q+Mec0OEJ/DqGB33M1nt284+cAa8EPq/k1hUkQQxM+y0cN085INGU1WcZ12hoqfg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.12.0/swagger-ui.min.css" integrity="sha512-c/nL8uV8W4bgSdxmZQDO0T+34SYDuurZMc2ylKRuqUvTn0CONDptVTnc7EPiXyaGZwsgv3l/i/PDuxV7RY54yw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 }

--- a/src/LondonTravel.Site/Pages/Help/Index.cshtml
+++ b/src/LondonTravel.Site/Pages/Help/Index.cshtml
@@ -21,11 +21,11 @@
     <p>
         To check for disruption on any of the supported Transport for London (TfL) lines, ask:
     </p>
-    <blockquote>
+    <blockquote class="blockquote">
         <p>
-            <i>
+            <em>
                 &quot;Alexa, ask London Travel are there any line closures?&quot;
-            </i>
+            </em>
         </p>
     </blockquote>
     <p>
@@ -43,11 +43,11 @@
         To check for the status of a specific London Underground line, the DLR,
         the Elizabeth line or London Overground, ask Alexa about the line you are interested in. For example:
     </p>
-    <blockquote>
+    <blockquote class="blockquote">
         <p>
-            <i>
+            <em>
                 &quot;Alexa, ask London Travel what's the status of the Northern line?&quot;
-            </i>
+            </em>
         </p>
     </blockquote>
 
@@ -66,7 +66,7 @@
         Once you have selected at least one favourite line for your commute, you can ask Alexa about your
         commute. Alexa will respond by telling you the status for each of your favourite lines.
     </p>
-    <blockquote>
+    <blockquote class="blockquote">
         <p>
             <i>
                 @SR.CommuteSkillInvocation
@@ -135,9 +135,27 @@
     <p>
         If you need any further help with either the London Travel Alexa skill, or this website, you can either:
         <ul>
-            <li>Open an issue in GitHub for the <a href="https://github.com/martincostello/alexa-london-travel/issues/new" rel="noopener noreferrer" target="_blank" title="Open GitHub issues for the London Travel Alexa skill" data-ga-label="Help GitHub Skill">skill <i class="fa fa-external-link" aria-hidden="true"></i></a></li>
-            <li>Open an issue in GitHub for this <a href="https://github.com/martincostello/alexa-london-travel-site/issues/new" rel="noopener noreferrer" target="_blank" title="Open GitHub issues for the London Travel Alexa website" data-ga-label="Help GitHub Site">website <i class="fa fa-external-link" aria-hidden="true"></i></a></li>
-            <li>Contact me over on <a href="https://twitter.com/@(Options.Metadata?.Author?.SocialMedia?.Twitter)" rel="noopener noreferrer" target="_blank" title="View Martin's Twitter profile." data-ga-label="Help Twitter">Twitter <i class="fa fa-external-link" aria-hidden="true"></i></a></li>
+            <li>
+                Open an issue in GitHub for the
+                <a href="https://github.com/martincostello/alexa-london-travel/issues/new" rel="noopener noreferrer" target="_blank" title="Open GitHub issues for the London Travel Alexa skill" data-ga-label="Help GitHub Skill">
+                    skill
+                    <span class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></span>
+                </a>
+            </li>
+            <li>
+                Open an issue in GitHub for this
+                <a href="https://github.com/martincostello/alexa-london-travel-site/issues/new" rel="noopener noreferrer" target="_blank" title="Open GitHub issues for the London Travel Alexa website" data-ga-label="Help GitHub Site">
+                    website
+                    <span class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></span>
+                </a>
+            </li>
+            <li>
+                Contact me over on
+                <a href="https://twitter.com/@(Options.Metadata?.Author?.SocialMedia?.Twitter)" rel="noopener noreferrer" target="_blank" title="View Martin's Twitter profile." data-ga-label="Help Twitter">
+                    Twitter
+                    <span class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></span>
+                </a>
+            </li>
         </ul>
     </p>
 </div>

--- a/src/LondonTravel.Site/Pages/Home/_AccountCreated.cshtml
+++ b/src/LondonTravel.Site/Pages/Home/_AccountCreated.cshtml
@@ -2,9 +2,7 @@
      string.Equals(Context.Request.Query["Message"], nameof(SiteMessage.AccountCreated), StringComparison.OrdinalIgnoreCase))
 {
     <div class="alert alert-success" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Dismiss Account Created">
-            <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Dismiss Account Created"></button>
         <p class="lead">
             @SR.AccountCreatedTitle
         </p>

--- a/src/LondonTravel.Site/Pages/Home/_AccountDeleted.cshtml
+++ b/src/LondonTravel.Site/Pages/Home/_AccountDeleted.cshtml
@@ -2,9 +2,7 @@
      string.Equals(Context.Request.Query["Message"], nameof(SiteMessage.AccountDeleted), StringComparison.OrdinalIgnoreCase))
 {
     <div class="alert alert-success" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Dismiss Account Deleted">
-            <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Dismiss Account Deleted"></button>
         <p class="lead">
             @SR.AccountDeletedTitle
         </p>

--- a/src/LondonTravel.Site/Pages/Home/_Jumbotron.cshtml
+++ b/src/LondonTravel.Site/Pages/Home/_Jumbotron.cshtml
@@ -1,24 +1,30 @@
 @{
     bool authenticationEnabled = Options?.Authentication?.IsEnabled == true;
 }
-<div class="jumbotron">
-    <h1>@SR.BrandName</h1>
-    <p class="lead">
-        @SR.HomepageLead
-    </p>
-    <p>
-        <a class="btn btn-primary" href="@Options?.ExternalLinks?.Skill" rel="noopener noreferrer" target="_blank" title="@SR.InstallLinkAltText" data-ga-label="Install Skill CTA">@SR.InstallLinkText <i class="fa fa-external-link" aria-hidden="true"></i></a>
-        @if (authenticationEnabled)
-        {
-            <a class="btn btn-primary hidden-xs" asp-page="@SiteRoutes.Register" title="@SR.RegisterLinkAltText" data-ga-label="Register CTA" data-id="register">@SR.RegisterLinkText <i class="fa fa-user-plus" aria-hidden="true"></i></a>
-            <a class="btn btn-primary hidden-xs" asp-route="@SiteRoutes.SignIn" title="@SR.SignInLinkAltText" data-ga-label="Sign-in CTA" data-id="sign-in">@SR.SignInLinkText <i class="fa fa-sign-in" aria-hidden="true"></i></a>
-        }
-    </p>
-    @if (authenticationEnabled)
-    {
-        <p class="visible-xs">
-            <a class="btn btn-primary" asp-page="@SiteRoutes.Register" title="@SR.RegisterLinkAltText" data-ga-label="Register CTA" data-id="register">@SR.RegisterLinkText <i class="fa fa-user-plus" aria-hidden="true"></i></a>
-            <a class="btn btn-primary" asp-route="@SiteRoutes.SignIn" title="@SR.SignInLinkAltText" data-ga-label="Sign-in CTA" data-id="sign-in">@SR.SignInLinkText <i class="fa fa-sign-in" aria-hidden="true"></i></a>
+<div class="bg-light mb-4 p-5 rounded-3">
+    <div class="container-fluid pt-2">
+        <h1 class="display-5 fw-bold">@SR.BrandName</h1>
+        <p class="lead">
+            @SR.HomepageLead
         </p>
-    }
+        <p>
+            <div class="col-12 col-sm-2 gap-2 vstack">
+                <a class="btn btn-primary" href="@Options?.ExternalLinks?.Skill" rel="noopener noreferrer" target="_blank" title="@SR.InstallLinkAltText" data-ga-label="Install Skill CTA">
+                    @SR.InstallLinkText
+                    <span class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></span>
+                </a>
+                @if (authenticationEnabled)
+                {
+                    <a class="btn btn-primary" asp-page="@SiteRoutes.Register" title="@SR.RegisterLinkAltText" data-ga-label="Register CTA" data-id="register">
+                        @SR.RegisterLinkText
+                        <span class="fa-solid fa-user-plus" aria-hidden="true"></span>
+                    </a>
+                    <a class="btn btn-primary" asp-route="@SiteRoutes.SignIn" title="@SR.SignInLinkAltText" data-ga-label="Sign-in CTA" data-id="sign-in">
+                        @SR.SignInLinkText
+                        <span class="fa-solid fa-right-to-bracket" aria-hidden="true"></span>
+                    </a>
+                }
+            </div>
+        </p>
+    </div>
 </div>

--- a/src/LondonTravel.Site/Pages/Home/_Lines.cshtml
+++ b/src/LondonTravel.Site/Pages/Home/_Lines.cshtml
@@ -1,11 +1,10 @@
 @model IEnumerable<FavoriteLineItem>
+<ul>
 @foreach (var line in Model!)
 {
-    <div class="col-xs-offset-1 col-xs-10 checkbox js-travel-line travel-line travel-line-@line.Id" data-line-preference>
-        <label for="preference-@line.Id">
-            <input class="js-line-preference" type="checkbox" id="preference-@line.Id" name="@(nameof(UpdateLinePreferencesViewModel.FavoriteLines))" value="@line.Id" data-line-id="@line.Id" data-line-name="@line.DisplayName" @(line.IsFavorite ? "checked" : string.Empty)>
-            <span class="cr"><i class="cr-icon fa fa-check"></i></span>
-            <span class="js-travel-line">@line.DisplayName</span>
-        </label>
-    </div>
+    <li class="checkbox js-travel-line list-group-item p-3 travel-line travel-line-@line.Id" data-line-preference>
+        <input class="form-check-input js-line-preference" type="checkbox" id="preference-@line.Id" name="@(nameof(UpdateLinePreferencesViewModel.FavoriteLines))" value="@line.Id" data-line-id="@line.Id" data-line-name="@line.DisplayName" @(line.IsFavorite ? "checked" : string.Empty)>
+        <label class="form-check-label js-travel-line" for="preference-@line.Id">@line.DisplayName</label>
+    </li>
 }
+</ul>

--- a/src/LondonTravel.Site/Pages/Home/_Preferences.cshtml
+++ b/src/LondonTravel.Site/Pages/Home/_Preferences.cshtml
@@ -29,11 +29,11 @@
             <p>
                 @SR.LinePreferencesNoneContent
             </p>
-            <blockquote>
+            <blockquote class="blockquote">
                 <p>
-                    <i>
+                    <em>
                         @SR.CommuteSkillInvocation
-                    </i>
+                    </em>
                 </p>
             </blockquote>
     }

--- a/src/LondonTravel.Site/Pages/Home/_SkillNotLinked.cshtml
+++ b/src/LondonTravel.Site/Pages/Home/_SkillNotLinked.cshtml
@@ -1,7 +1,5 @@
 <div class="alert alert-info" role="alert">
-    <button type="button" class="close" data-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Dismiss Skill Not Linked">
-        <span aria-hidden="true">&times;</span>
-    </button>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Dismiss Skill Not Linked"></button>
     <p class="lead">
         @SR.SkillNotLinkedTitle
     </p>

--- a/src/LondonTravel.Site/Pages/Home/_UpdateFailure.cshtml
+++ b/src/LondonTravel.Site/Pages/Home/_UpdateFailure.cshtml
@@ -3,9 +3,7 @@
 {
     <div class="sr-only">@SR.UpdateFailureModalDescription</div>
     <div class="alert alert-warning" role="alert" aria-hidden="true">
-        <button type="button" class="close" data-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Save Preferences Failure Dismissed">
-            <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Save Preferences Failure Dismissed"></button>
         <p class="lead">
             @SR.UpdateFailureModalTitle
         </p>

--- a/src/LondonTravel.Site/Pages/Home/_UpdateForm.cshtml
+++ b/src/LondonTravel.Site/Pages/Home/_UpdateForm.cshtml
@@ -4,7 +4,7 @@
     @if (Model!.HasFavorites)
     {
         <div class="row">
-            <h4 class="col-xs-offset-1">@SR.FavoriteLinesTitle("hide js-favorites-count", Model.FavoriteLines.Count())</h4>
+            <h4 class="col-xs-offset-1">@SR.FavoriteLinesTitle("d-none js-favorites-count", Model.FavoriteLines.Count())</h4>
             @await Html.PartialAsync("_Lines", Model.FavoriteLines)
         </div>
     }
@@ -12,7 +12,7 @@
     {
         <div class="row">
             @{
-                var classes = Model.HasFavorites ? "hide js-other-count" : string.Empty;
+                var classes = Model.HasFavorites ? "d-none js-other-count" : string.Empty;
                 var count = Model.OtherLines.Count();
                 var otherTitle = Model.HasFavorites ?
                     SR.OtherLinesTitle(classes, count) :
@@ -23,15 +23,9 @@
         </div>
     }
     <hr />
-    <div class="row">
-        <div class="col-xs-10 col-xs-offset-1 col-md-3 col-md-offset-1 btn-wrapper">
-            <button type="submit" class="btn btn-primary btn-block js-preferences-save" title="@SR.SavePreferencesButtonAltText" data-id="save-preferences" data-toggle="modal" data-target=".update-preferences-modal">@SR.SavePreferencesButtonText</button>
-        </div>
-        <div class="col-xs-10 col-xs-offset-1 col-md-3 col-md-offset-0 btn-wrapper">
-            <button type="button" class="btn btn-info hide btn-block js-preferences-clear" title="@SR.ClearPreferencesButtonAltText">@SR.ClearPreferencesButtonText</button>
-        </div>
-        <div class="col-xs-10 col-xs-offset-1 col-md-3 col-md-offset-0 btn-wrapper">
-            <button type="button" class="btn btn-info hide btn-block js-preferences-reset" title="@SR.ResetPreferencesButtonAltText">@SR.ResetPreferencesButtonText</button>
-        </div>
+    <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary js-preferences-save flex-fill" title="@SR.SavePreferencesButtonAltText" data-id="save-preferences" data-bs-toggle="modal" data-bs-target=".update-preferences-modal">@SR.SavePreferencesButtonText</button>
+        <button type="button" class="btn btn-info js-preferences-clear flex-fill" title="@SR.ClearPreferencesButtonAltText">@SR.ClearPreferencesButtonText</button>
+        <button type="button" class="btn btn-info js-preferences-reset flex-fill" title="@SR.ResetPreferencesButtonAltText">@SR.ResetPreferencesButtonText</button>
     </div>
 </form>

--- a/src/LondonTravel.Site/Pages/Home/_UpdateModal.cshtml
+++ b/src/LondonTravel.Site/Pages/Home/_UpdateModal.cshtml
@@ -2,15 +2,13 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="@SR.CloseButtonText" data-ga-label="Save Preferences Dismiss">
-                    <span aria-hidden="true">&times;</span>
-                </button>
                 <h4 class="modal-title" id="update-preferences-modal-title">@SR.UpdateProgressModalTitle</h4>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="@SR.CloseButtonText" data-ga-label="Save Preferences Dismiss"></button>
                 <div class="sr-only" id="update-preferences-modal-description">@SR.UpdateProgressModalDescription</div>
             </div>
-            <div class="modal-body">
+            <div class="modal-body d-flex aligns-items-center justify-content-center">
                 <p>
-                    <div class="center-block loader" aria-hidden="true"></div>
+                    <div class="loader" aria-hidden="true"></div>
                 </p>
             </div>
         </div>

--- a/src/LondonTravel.Site/Pages/Home/_UpdateSuccess.cshtml
+++ b/src/LondonTravel.Site/Pages/Home/_UpdateSuccess.cshtml
@@ -3,9 +3,7 @@
 {
     <div class="sr-only">@SR.UpdateSuccessModalTitle</div>
     <div class="alert alert-success" role="alert" aria-hidden="true">
-        <button type="button" class="close" data-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Save Preferences Success Dismissed">
-            <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Save Preferences Success Dismissed"></button>
         <p class="lead">
             @SR.UpdateSuccessModalTitle
         </p>

--- a/src/LondonTravel.Site/Pages/Shared/_AccountLinkDenied.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_AccountLinkDenied.cshtml
@@ -1,9 +1,7 @@
 ﻿@if (string.Equals(Context.Request.Query["Message"].FirstOrDefault(), nameof(SiteMessage.LinkDenied), StringComparison.OrdinalIgnoreCase))
 {
     <div class="alert alert-warning" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Account Link Denied Dismiss">
-            <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Account Link Denied Dismiss"></button>
         <p class="lead">
             @SR.AccountLinkDeniedTitle
         </p>

--- a/src/LondonTravel.Site/Pages/Shared/_AccountLinkFailed.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_AccountLinkFailed.cshtml
@@ -2,9 +2,7 @@
      string.Equals(Context.Request.Query["Message"].FirstOrDefault(), nameof(SiteMessage.Error), StringComparison.OrdinalIgnoreCase))
 {
     <div class="alert alert-warning" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Account Link Failed Dismiss">
-            <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Account Link Failed Dismiss"></button>
         <p class="lead">
             @SR.AccountLinkFailedTitle
         </p>

--- a/src/LondonTravel.Site/Pages/Shared/_AlreadyRegistered.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_AlreadyRegistered.cshtml
@@ -1,9 +1,7 @@
 ﻿@if (string.Equals(ViewData["Message"] as string, nameof(SiteMessage.AlreadyRegistered), StringComparison.OrdinalIgnoreCase))
 {
     <div class="alert alert-warning" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Already Registered Dismiss">
-            <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Already Registered Dismiss"></button>
         <p class="lead">
             @SR.AlreadyRegisteredTitle
         </p>

--- a/src/LondonTravel.Site/Pages/Shared/_Footer.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_Footer.cshtml
@@ -1,41 +1,23 @@
 @model SiteOptions
 <hr />
 <footer>
-    <p class="hidden-sm hidden-xs">
+    <p>
         @SR.CopyrightText |
-        <a asp-page="@SiteRoutes.Help" title="@SR.HelpLinkAltText" data-ga-label="Help Footer">
+        <a class="text-nowrap" asp-page="@SiteRoutes.Help" title="@SR.HelpLinkAltText" data-ga-label="Help Footer">
             @SR.HelpLinkText
         </a>
         |
-        <a asp-page="@SiteRoutes.PrivacyPolicy" title="@SR.PrivacyPolicyLinkAltText" data-ga-label="Privacy Policy Footer">
+        <a class="text-nowrap" asp-page="@SiteRoutes.PrivacyPolicy" title="@SR.PrivacyPolicyLinkAltText" data-ga-label="Privacy Policy Footer">
             @SR.PrivacyPolicyLinkText
         </a>
         |
-        <a asp-page="@SiteRoutes.TermsOfService" title="@SR.TermsOfServiceLinkAltText" data-ga-label="Terms of Service Footer">
+        <a class="text-nowrap" asp-page="@SiteRoutes.TermsOfService" title="@SR.TermsOfServiceLinkAltText" data-ga-label="Terms of Service Footer">
             @SR.TermsOfServiceLinkText
         </a>
         |
-        <a asp-page="@SiteRoutes.Technology" title="@SR.TechnologyLinkAltText" data-ga-label="Technology Footer">
+        <a class="text-nowrap" asp-page="@SiteRoutes.Technology" title="@SR.TechnologyLinkAltText" data-ga-label="Technology Footer">
             @SR.TechnologyLinkText
         </a>
-        <span id="build-date" data-format="YYYY-MM-DD HH:mm Z" data-timestamp="@GitMetadata.Timestamp.ToString("u", CultureInfo.InvariantCulture)"></span>
+        <span id="build-date" class="d-none d-sm-inline" data-format="YYYY-MM-DD HH:mm Z" data-timestamp="@GitMetadata.Timestamp.ToString("u", CultureInfo.InvariantCulture)"></span>
     </p>
-    <div class="row hidden-md hidden-lg">
-        <div class="col-sm-12 col-xs-12">
-            @SR.CopyrightText
-        </div>
-        <div class="col-sm-12 col-xs-12">
-            <a asp-page="@SiteRoutes.Help" title="@SR.HelpLinkAltText" data-ga-label="Help Footer">
-                @SR.HelpLinkText
-            </a>
-            |
-            <a asp-page="@SiteRoutes.PrivacyPolicy" title="@SR.PrivacyPolicyLinkAltText" data-ga-label="Privacy Policy Footer">
-                @SR.PrivacyPolicyLinkText
-            </a>
-            |
-            <a asp-page="@SiteRoutes.TermsOfService" title="@SR.TermsOfServiceLinkAltText" data-ga-label="Terms of Service Footer">
-                @SR.TermsOfServiceLinkText
-            </a>
-        </div>
-    </div>
 </footer>

--- a/src/LondonTravel.Site/Pages/Shared/_Layout.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_Layout.cshtml
@@ -25,7 +25,6 @@
     @await Html.PartialAsync("_Links", Tuple.Create(canonicalUri, Options))
     @await RenderSectionAsync("links", required: false)
     @await RenderSectionAsync("meta", required: false)
-    @await Html.PartialAsync("_StylesHead")
     @await RenderSectionAsync("stylesHead", required: false)
     <script type="text/javascript" nonce="@Context.EnsureCspNonce()">
         @Html.Raw(JavaScriptSnippet.ScriptBody)

--- a/src/LondonTravel.Site/Pages/Shared/_Links.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_Links.cshtml
@@ -5,20 +5,20 @@
 }
     <link rel="dns-prefetch" href="https://@options?.ExternalLinks?.Cdn?.Host">
     <link rel="dns-prefetch" href="https://az416426.vo.msecnd.net">
+    <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="dns-prefetch" href="https://dc.services.visualstudio.com">
     <link rel="dns-prefetch" href="https://fonts.googleapis.com">
     <link rel="dns-prefetch" href="https://fonts.gstatic.com">
-    <link rel="dns-prefetch" href="https://stackpath.bootstrapcdn.com">
     <link rel="dns-prefetch" href="https://www.googletagmanager.com">
     <link rel="dns-prefetch" href="https://www.gravatar.com">
     <link rel="preconnect" href="https://@options?.ExternalLinks?.Cdn?.Host">
     <link rel="preconnect" href="https://az416426.vo.msecnd.net">
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://dc.services.visualstudio.com">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link rel="preconnect" href="https://stackpath.bootstrapcdn.com">
     <link rel="preconnect" href="https://www.googletagmanager.com">
     <link rel="preconnect" href="https://www.gravatar.com">
     <link rel="canonical" href="@canonical">

--- a/src/LondonTravel.Site/Pages/Shared/_Navbar.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_Navbar.cshtml
@@ -1,72 +1,72 @@
-<nav class="navbar navbar-default navbar-fixed-top">
+<nav class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
     <div class="container">
-        <div class="navbar-header">
-            <a asp-page="@SiteRoutes.Home" class="navbar-brand" title="@SR.HomepageLinkAltText" data-ga-label="Homepage Navbar">
-                <span>
-                    @SR.BrandName
-                    <lazyimg src="@Url.CdnContent("avatar.png", Options)" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
-                    <noscript>
-                        <img src="@Url.CdnContent("avatar.png", Options)" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
-                    </noscript>
-                </span>
-            </a>
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse" data-ga-label="Navbar Collapse">
-                <span class="sr-only">@SR.NavbarCollapseAltText</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
-        </div>
-        <div class="navbar-collapse collapse">
-            <ul class="nav navbar-nav">
-                <li class="dropdown">
-                    <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" data-ga-label="Navbar Menu">
-                        @SR.NavbarMenuText <span class="caret"></span>
+        <a asp-page="@SiteRoutes.Home" class="navbar-brand" title="@SR.HomepageLinkAltText" data-ga-label="Homepage Navbar">
+            <span>
+                @SR.BrandName
+                <lazyimg src="@Url.CdnContent("avatar.png", Options)" class="pb-1" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
+                <noscript>
+                    <img src="@Url.CdnContent("avatar.png", Options)" class="pb-1" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
+                </noscript>
+            </span>
+        </a>
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbar-collapse" aria-expanded="false" aria-label="@SR.NavbarCollapseAltText">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="navbar-collapse collapse" id="navbar-collapse">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" id="navbar-dropdown" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" data-ga-label="Navbar Menu">
+                        @SR.NavbarMenuText
                     </a>
-                    <ul class="dropdown-menu">
+                    <ul class="dropdown-menu" aria-labelledby="navbar-dropdown">
                         <li>
-                            <a href="@Options?.ExternalLinks?.Skill" rel="noopener noreferrer" target="_blank" title="@SR.InstallLinkAltText" data-ga-label="Install Navbar">
+                            <a class="dropdown-item" href="@Options?.ExternalLinks?.Skill" rel="noopener noreferrer" target="_blank" title="@SR.InstallLinkAltText" data-ga-label="Install Navbar">
                                 @SR.InstallLinkText
-                                <i class="fa fa-external-link" aria-hidden="true"></i>
+                                <span class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></span>
                             </a>
                         </li>
                         @if (Options?.Authentication?.IsEnabled == true)
                         {
-                            <li role="separator" class="divider"></li>
+                            <li><hr class="dropdown-divider"></li>
                             @if (User?.Identity?.IsAuthenticated == true)
                             {
                                 <li>
-                                    <a asp-route="@SiteRoutes.Manage" title="@SR.ManageLinkAltText" data-ga-label="Manage Account Navbar">
-                                        @SR.ManageLinkText <i class="fa fa-user" aria-hidden="true"></i>
+                                    <a class="dropdown-item" asp-route="@SiteRoutes.Manage" title="@SR.ManageLinkAltText" data-ga-label="Manage Account Navbar">
+                                        @SR.ManageLinkText
+                                        <span class="fa-solid fa-user" aria-hidden="true"></span>
                                     </a>
                                 </li>
                             }
                             else
                             {
                                 <li>
-                                    <a asp-page="@SiteRoutes.Register" title="@SR.RegisterLinkAltText" data-ga-label="Register Navbar">@SR.RegisterLinkText <i class="fa fa-user-plus" aria-hidden="true"></i></a>
+                                    <a class="dropdown-item" asp-page="@SiteRoutes.Register" title="@SR.RegisterLinkAltText" data-ga-label="Register Navbar">
+                                        @SR.RegisterLinkText
+                                        <span class="fa-solid fa-user-plus" aria-hidden="true"></span>
+                                    </a>
                                 </li>
                             }
                         }
-                        <li role="separator" class="divider"></li>
+                        <li><hr class="dropdown-divider"></li>
                         <li>
-                            <a asp-page="@SiteRoutes.Help" title="@SR.HelpLinkAltText" data-ga-label="Help Navbar">
-                                @SR.HelpLinkText <i class="fa fa-question-circle" aria-hidden="true"></i>
+                            <a class="dropdown-item" asp-page="@SiteRoutes.Help" title="@SR.HelpLinkAltText" data-ga-label="Help Navbar">
+                                @SR.HelpLinkText
+                                <span class="fa-solid fa-circle-question" aria-hidden="true"></span>
                             </a>
                         </li>
                         <li>
-                            <a asp-page="@SiteRoutes.PrivacyPolicy" title="@SR.PrivacyPolicyLinkAltText" data-ga-label="Privacy Policy Navbar">
+                            <a class="dropdown-item" asp-page="@SiteRoutes.PrivacyPolicy" title="@SR.PrivacyPolicyLinkAltText" data-ga-label="Privacy Policy Navbar">
                                 @SR.PrivacyPolicyLinkText
                             </a>
                         </li>
                         <li>
-                            <a asp-page="@SiteRoutes.TermsOfService" title="@SR.TermsOfServiceLinkAltText" data-ga-label="Terms of Service Navbar">
+                            <a class="dropdown-item" asp-page="@SiteRoutes.TermsOfService" title="@SR.TermsOfServiceLinkAltText" data-ga-label="Terms of Service Navbar">
                                 @SR.TermsOfServiceLinkText
                             </a>
                         </li>
-                        <li role="separator" class="divider"></li>
+                        <li><hr class="dropdown-divider"></li>
                         <li>
-                            <a asp-page="@SiteRoutes.Technology" title="@SR.TechnologyLinkAltText" data-ga-label="Technology Navbar">
+                            <a class="dropdown-item" asp-page="@SiteRoutes.Technology" title="@SR.TechnologyLinkAltText" data-ga-label="Technology Navbar">
                                 @SR.TechnologyLinkText
                             </a>
                         </li>

--- a/src/LondonTravel.Site/Pages/Shared/_PermissionDenied.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_PermissionDenied.cshtml
@@ -1,9 +1,7 @@
 ﻿@if (string.Equals(ViewData["Message"] as string, nameof(SiteMessage.PermissionDenied), StringComparison.OrdinalIgnoreCase))
 {
     <div class="alert alert-warning" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Permission Denied Dismiss">
-            <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Permission Denied Dismiss"></button>
         <p class="lead">
             @SR.PermissionDeniedTitle
         </p>

--- a/src/LondonTravel.Site/Pages/Shared/_Scripts.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_Scripts.cshtml
@@ -1,10 +1,10 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.min.js" integrity="sha512-jNDtFf7qgU0eH/+Z42FG4fw3w7DM/9zbgNPe3wfJlCylVDTT3IgKW5r92Vy9IHa6U50vyMz5gRByIu4YIXFtaQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.3/moment.min.js" integrity="sha512-dGM81hdEjiW5IomkknOx3fIfwij3c7xwh6TcrbumlkHJtO81OKNjLISJaPEhCgVxM6+0uGJ7KRmI2YJFn0AmHQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js" integrity="sha512-+H4iLjY3JsKiF2V6N366in5IQHj2uEsGV7Pp/GRcm0fn76aPAk5V8xB6n8fQhhSonTqTXs/klFz4D0GIn6Br9g==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
 @if (string.Equals(CultureInfo.CurrentUICulture.Name, "en-GB", StringComparison.Ordinal))
 {
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.3/locale/en-gb.min.js" integrity="sha512-w+tDY4gx49+DNVlN7Nmc9ldOkh6nP3w4txBTEatSx3XrZdfYtX9+oylJjQ7RqeeDzDebG3u1VAg/gM5Td2Bd5Q==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/locale/en-gb.min.js" integrity="sha512-w+tDY4gx49+DNVlN7Nmc9ldOkh6nP3w4txBTEatSx3XrZdfYtX9+oylJjQ7RqeeDzDebG3u1VAg/gM5Td2Bd5Q==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
 }
 @{
     var analyticsId = Options.Analytics?.Google;

--- a/src/LondonTravel.Site/Pages/Shared/_SignInForm.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_SignInForm.cshtml
@@ -14,13 +14,15 @@
             .ToList();
     }
 }
-<form asp-route="@SiteRoutes.ExternalSignIn" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" class="form-horizontal">
+<form asp-route="@SiteRoutes.ExternalSignIn" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post">
     <div>
         <p>
-            @foreach (var scheme in schemes)
-            {
-                @await Html.PartialAsync("_SocialButton", scheme)
-            }
+            <div class="vstack gap-2">
+                @foreach (var scheme in schemes)
+                {
+                    @await Html.PartialAsync("_SocialButton", scheme)
+                }
+            </div>
         </p>
     </div>
 </form>

--- a/src/LondonTravel.Site/Pages/Shared/_SignInModal.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_SignInModal.cshtml
@@ -1,16 +1,14 @@
-﻿<div class="modal sign-in-modal" tabindex="-1" role="dialog" aria-describedby="sign-in-modal-description" aria-labelledby="sign-in-modal-title">
-    <div class="modal-dialog" role="document">
+<div class="modal sign-in-modal" tabindex="-1" aria-describedby="sign-in-modal-description" aria-labelledby="sign-in-modal-title">
+    <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="@SR.CloseButtonText" data-ga-label="Sign-In Dismiss">
-                    <span aria-hidden="true">&times;</span>
-                </button>
                 <h4 class="modal-title" id="sign-in-modal-title">@SR.SigningInModalTitle</h4>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="@SR.CloseButtonText" data-ga-label="Sign-In Dismiss"></button>
                 <div class="sr-only" id="sign-in-modal-description">@SR.SigningInModalDescription</div>
             </div>
-            <div class="modal-body">
+            <div class="modal-body d-flex aligns-items-center justify-content-center">
                 <p>
-                    <div class="center-block loader" aria-hidden="true"></div>
+                    <div class="loader" aria-hidden="true"></div>
                 </p>
             </div>
         </div>

--- a/src/LondonTravel.Site/Pages/Shared/_SignInPartial.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_SignInPartial.cshtml
@@ -5,10 +5,10 @@
 }
 @if (SignInManager.IsSignedIn(User))
 {
-    <form asp-route="@SiteRoutes.SignOut" method="post" class="navbar-right">
+    <form asp-route="@SiteRoutes.SignOut" method="post">
         <ul class="nav navbar-nav navbar-right">
             <li>
-                <a asp-route="@SiteRoutes.Manage" title="@SR.ManageLinkAltText" data-ga-label="Manage Account Navbar">
+                <a class="nav-link" asp-route="@SiteRoutes.Manage" title="@SR.ManageLinkAltText" data-ga-label="Manage Account Navbar">
                     <span data-id="user-name">@displayName</span>
                     <lazyimg alt="@displayName" title="@displayName" src="@avatarUrl" aria-hidden="true" />
                     <noscript>
@@ -17,9 +17,9 @@
                 </a>
             </li>
             <li>
-                <button type="submit" class="btn btn-link navbar-btn navbar-link" title="@SR.SignOutLinkText" data-id="sign-out" data-ga-label="Sign-Out Navbar">
+                <button type="submit" class="btn btn-link navbar-btn nav-link" title="@SR.SignOutLinkText" data-id="sign-out" data-ga-label="Sign-Out Navbar">
                     @SR.SignOutLinkText
-                    <i class="fa fa-sign-out" aria-hidden="true"></i>
+                    <span class="fa-solid fa-right-from-bracket" aria-hidden="true"></span>
                 </button>
             </li>
         </ul>
@@ -28,7 +28,15 @@
 else
 {
     <ul class="nav navbar-nav navbar-right">
-        <li><a asp-route="@SiteRoutes.SignIn" rel="nofollow" title="@SR.SignInLinkAltText" data-ga-label="Sign-In Navbar">@SR.SignInLinkText</a></li>
-        <li><a asp-page="@SiteRoutes.Register" title="@SR.RegisterLinkAltText" data-ga-label="Register Navbar">@SR.RegisterLinkText</a></li>
+        <li>
+            <a class="nav-link" asp-route="@SiteRoutes.SignIn" rel="nofollow" title="@SR.SignInLinkAltText" data-ga-label="Sign-In Navbar">
+                @SR.SignInLinkText
+            </a>
+        </li>
+        <li>
+            <a class="nav-link" asp-page="@SiteRoutes.Register" title="@SR.RegisterLinkAltText" data-ga-label="Register Navbar">
+                @SR.RegisterLinkText
+            </a>
+        </li>
     </ul>
 }

--- a/src/LondonTravel.Site/Pages/Shared/_SocialButton.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_SocialButton.cshtml
@@ -1,13 +1,13 @@
 @model Microsoft.AspNetCore.Authentication.AuthenticationScheme
 <button type="submit"
-        class="btn btn-block btn-social @Html.GetSocialLoginButtonCss(Model!.Name)"
+        class="btn btn-lg btn-primary btn-social @Html.GetSocialLoginButtonCss(Model!.Name)"
         name="provider"
         value="@Model.Name"
         title="@SR.SignInButtonAltText(Model.DisplayName!)"
         data-id="sign-in-@Model.Name.ToLowerInvariant()"
         data-ga-label="Sign-In - @Model.DisplayName"
-        data-target=".sign-in-modal"
-        data-toggle="modal">
+        data-bs-target=".sign-in-modal"
+        data-bs-toggle="modal">
     @await Html.PartialAsync("_SocialIcon", Model.Name)
     @SR.SignInButtonText(Model.DisplayName!)
 </button>

--- a/src/LondonTravel.Site/Pages/Shared/_SocialIcon.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_SocialIcon.cshtml
@@ -1,2 +1,2 @@
-﻿@model string
-<i class="fa @Html.GetSocialLoginIconCss(Model!)" aria-hidden="true"></i>
+@model string
+<span class="fa-brands @(Html.GetSocialLoginIconCss(Model!)) mt-1" aria-hidden="true"></span>

--- a/src/LondonTravel.Site/Pages/Shared/_StylesBody.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_StylesBody.cshtml
@@ -1,5 +1,5 @@
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootswatch/3.4.1/flatly/bootstrap.min.css" integrity="sha384-bfWZLPtvQKHg/nZNhaO/ZW4Ba8ISud5CtEjnCTU6OR1yOq5zrrF+JP2o7om6rzLf" crossorigin="anonymous">
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.1.3/dist/flatly/bootstrap.min.css" integrity="sha384-JJl14kOPjuUj+o0fDTJGBSCDKpu1A4BuCmARIetHUvTVmopvVZITFd4AhRMJIlz7" crossorigin="anonymous" referrerpolicy="no-referrer">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous" referrerpolicy="no-referrer">
 <environment names="Development">
     <link rel="stylesheet" href="~/assets/css/site.css" asp-append-version="true" asp-csp-nonce="@Context.EnsureCspNonce()" asp-inline="true" asp-minify-inlined="true">
 </environment>

--- a/src/LondonTravel.Site/Pages/Technology/Index.cshtml
+++ b/src/LondonTravel.Site/Pages/Technology/Index.cshtml
@@ -12,7 +12,7 @@
         code is hosted in
         <a href="https://github.com/martincostello/alexa-london-travel" rel="noopener noreferrer" target="_blank" title="London Travel on GitHub" data-ga-label="London Travel Skill GitHub">
             GitHub.
-            <i class="fa fa-external-link" aria-hidden="true"></i>
+            <span class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></span>
         </a>
     </p>
     <p>
@@ -20,7 +20,7 @@
         Docklands Light Railway (DLR), the Elizabeth line and London Overground using the
         <a href="https://api.tfl.gov.uk/" rel="noopener noreferrer" target="_blank" title="The TfL API" data-ga-label="TfL API">
             Transport for London (TfL) API.
-            <i class="fa fa-external-link" aria-hidden="true"></i>
+            <span class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></span>
         </a>
     </p>
     <p>
@@ -33,12 +33,12 @@
             The skill itself is written in C# for .NET using the
             <a href="https://github.com/timheuer/alexa-skills-dotnet" rel="noopener noreferrer" target="_blank" title="Alexa.NET on GitHub" data-ga-label="Alexa.NET">
                 Alexa.NET
-                <i class="fa fa-external-link" aria-hidden="true"></i>
+                <span class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></span>
             </a>
             library for the intents it provides for use with an Alexa-enabled device. The code itself is hosted in
             <a href="https://aws.amazon.com/" rel="noopener noreferrer" target="_blank" title="Amazon Web Services" data-ga-label="Amazon Web Services">
                 Amazon Web Services (AWS)
-                <i class="fa fa-external-link" aria-hidden="true"></i>
+                <span class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></span>
             </a>
             as an AWS Lambda function. It can also be linked to an account created using this website to enable
             personalisation, such as for the status of lines you regularly use.
@@ -72,7 +72,7 @@
             This website is written in C# for ASP.NET Core with HTML and TypeScript, and is hosted in
             <a href="https://azure.microsoft.com/" rel="noopener noreferrer" target="_blank" title="Microsoft Azure" data-ga-label="Microsoft Azure">
                 Microsoft Azure.
-                <i class="fa fa-external-link" aria-hidden="true"></i>
+                <span class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></span>
             </a>
         </p>
         <p>
@@ -94,7 +94,6 @@
                 <li>Azure Key Vault</li>
                 <li>Bootstrap</li>
                 <li>Bootswatch</li>
-                <li>BundlerMinifier</li>
                 <li>CloudFlare CDN</li>
                 <li>coverlet</li>
                 <li>DNSimple</li>
@@ -105,7 +104,6 @@
                 <li>Google Analytics</li>
                 <li>Gravatar</li>
                 <li>gulp</li>
-                <li>Jasmine</li>
                 <li>jQuery</li>
                 <li>jquery.lazyload</li>
                 <li>Microsoft Accounts</li>
@@ -114,7 +112,6 @@
                 <li>NodaTime</li>
                 <li>npm</li>
                 <li>NuGet</li>
-                <li>PhantomJS</li>
                 <li>Polly</li>
                 <li>Refit</li>
                 <li>report-uri.io</li>
@@ -139,14 +136,14 @@
                     alexa-app-server:
                     <a href="https://github.com/alexa-js/alexa-app-server/pull/88" rel="noopener noreferrer" target="_blank" title="View alexa-app-server Pull Request on GitHub" data-ga-label="alexa-app-server PR 88">
                         Support additional request properties in test page
-                        <i class="fa fa-external-link" aria-hidden="true"></i>
+                        <span class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></span>
                     </a>
                 </li>
                 <li>
                     AspNet.Security.OAuth.Providers:
                     <a href="https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/pull/157" rel="noopener noreferrer" target="_blank" title="View AspNet.Security.OAuth.Providers Pull Request on GitHub" data-ga-label="AspNet.Security.OAuth.Providers PR 157">
                         Add Amazon provider
-                        <i class="fa fa-external-link" aria-hidden="true"></i>
+                        <span class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></span>
                     </a>
                 </li>
             </ul>
@@ -156,7 +153,7 @@
         <h3>Acknowledgements</h3>
         <p>
             Thank you to all the Open Source Software, their contributors, and free services, that make this skill and website possible.
-            <i class="fa fa-heart" aria-hidden="true"></i>
+            <span class="fa-solid fa-heart" aria-hidden="true"></span>
         </p>
     </section>
 </div>

--- a/src/LondonTravel.Site/Views/Account/SignIn.cshtml
+++ b/src/LondonTravel.Site/Views/Account/SignIn.cshtml
@@ -13,7 +13,7 @@
             @await Html.PartialAsync("_SignInForm")
         </section>
     </div>
-    <hr class="hidden-md hidden-lg" />
+    <hr class="d-md-none" />
     <div class="col-md-8">
         <section>
             <h3>@SR.SignInRegisterSubtitle</h3>
@@ -23,7 +23,7 @@
             <p>
                 <a class="btn btn-primary btn-lg" asp-page="@SiteRoutes.Register" title="@SR.RegisterLinkAltText" data-ga-label="Register (Button)">
                     @SR.RegisterLinkText
-                    <i class="fa fa-user-plus" aria-hidden="true"></i>
+                    <span class="fa-solid fa-user-plus" aria-hidden="true"></span>
                 </a>
             </p>
         </section>

--- a/src/LondonTravel.Site/Views/Account/SignInAlexa.cshtml
+++ b/src/LondonTravel.Site/Views/Account/SignInAlexa.cshtml
@@ -15,11 +15,11 @@
     <p>
         @SR.AlexaSignInParagraph3
     </p>
-    <blockquote>
+    <blockquote class="blockquote">
         <p>
-            <i>
+            <em>
                 @SR.CommuteSkillInvocation
-            </i>
+            </em>
         </p>
     </blockquote>
 </section>

--- a/src/LondonTravel.Site/Views/Manage/Index.cshtml
+++ b/src/LondonTravel.Site/Views/Manage/Index.cshtml
@@ -14,12 +14,14 @@
         <p data-id="alexa-link" data-is-linked="@Model.IsLinkedToAlexa.ToString().ToLowerInvariant()">
             @if (Model.IsLinkedToAlexa)
             {
-                @SR.ManageLinkedToAlexa <i class="fa fa-check text-success" aria-hidden="true"></i>
+                @SR.ManageLinkedToAlexa
+                <span class="fa-solid fa-check text-success" aria-hidden="true"></span>
                 @await Html.PartialAsync("_RemoveAlexaLinkModal", Model)
             }
             else
             {
-                @SR.ManageNotLinkedToAlexa <i class="fa fa-times text-danger" aria-hidden="true"></i>
+                @SR.ManageNotLinkedToAlexa
+                <span class="fa-solid fa-xmark text-danger" aria-hidden="true"></span>
             }
         </p>
         <hr />
@@ -33,23 +35,23 @@
                     <tr data-linked-account data-provider="@provider.LoginProvider">
                         <td class="lead">
                             @await Html.PartialAsync("_SocialIcon", provider.LoginProvider)
-                            <span>@provider.ProviderDisplayName</span>
+                            <span class="brand-name">@provider.ProviderDisplayName</span>
                         </td>
                         <td>
                             @if (Model.ShowRemoveButton)
                             {
-                                <form asp-route="@SiteRoutes.RemoveAccountLink" method="post" class="form-horizontal">
+                                <form asp-route="@SiteRoutes.RemoveAccountLink" method="post">
                                     <div>
                                         <input asp-for="@provider.LoginProvider" name="LoginProvider" type="hidden" />
                                         <input asp-for="@provider.ProviderKey" name="ProviderKey" type="hidden" />
                                         <input type="submit"
-                                               class="btn btn-default"
+                                               class="btn btn-outline-danger"
                                                value="@SR.RemoveAccountButtonText"
                                                title="@SR.RemoveAccountButtonAltText(provider.ProviderDisplayName)"
                                                data-id="remove-@provider.LoginProvider.ToLowerInvariant()-link"
                                                data-ga-label="Remove Account Link - @provider.ProviderDisplayName"
-                                               data-toggle="modal"
-                                               data-target=".remove-link-modal"
+                                               data-bs-toggle="modal"
+                                               data-bs-target=".remove-link-modal"
                                                />
                                     </div>
                                 </form>
@@ -69,13 +71,15 @@
         <div class="col-md-4">
             <h3>@SR.ManageLinkOtherAccountsSubtitle</h3>
             <hr />
-            <form asp-route="@SiteRoutes.LinkAccount" method="post" class="form-horizontal">
+            <form asp-route="@SiteRoutes.LinkAccount" method="post">
                 <div>
                     <p>
-                        @foreach (var scheme in Model?.OtherLogins!)
-                        {
-                            @await Html.PartialAsync("_SocialButton", scheme)
-                        }
+                        <div class="vstack gap-2">
+                            @foreach (var scheme in Model?.OtherLogins!)
+                            {
+                                @await Html.PartialAsync("_SocialButton", scheme)
+                            }
+                        </div>
                     </p>
                 </div>
             </form>

--- a/src/LondonTravel.Site/Views/Manage/_DeleteAccount.cshtml
+++ b/src/LondonTravel.Site/Views/Manage/_DeleteAccount.cshtml
@@ -1,14 +1,14 @@
 <noscript>
     <hr />
-    <form asp-route="@SiteRoutes.DeleteAccount" method="post" class="form-horizontal">
+    <form asp-route="@SiteRoutes.DeleteAccount" method="post">
         <div>
             <input type="submit" class="btn btn-danger" value="@SR.DeleteAccountButtonText" title="@SR.DeleteAccountButtonAltText" />
         </div>
     </form>
 </noscript>
-<div class="hide js-hidden-control">
+<div class="d-none js-hidden-control">
     <hr />
-    <button class="btn btn-danger" title="@SR.DeleteAccountButtonAltText" data-id="delete-account" data-ga-label="Delete Account" data-toggle="modal" data-target="#delete-account-modal">
+    <button class="btn btn-danger" title="@SR.DeleteAccountButtonAltText" data-id="delete-account" data-ga-label="Delete Account" data-bs-toggle="modal" data-bs-target="#delete-account-modal">
         @SR.DeleteAccountButtonText
     </button>
 </div>
@@ -16,10 +16,8 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close js-delete-content" data-dismiss="modal" aria-label="@SR.CloseButtonText" data-ga-label="Delete Account Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
                 <h4 class="modal-title" id="delete-account-modal-title">@SR.DeleteAccountModalTitle</h4>
+                <button type="button" class="btn-close js-delete-content" data-bs-dismiss="modal" aria-label="@SR.CloseButtonText" data-ga-label="Delete Account Close"></button>
             </div>
             <div class="modal-body">
                 <div class="js-delete-content">
@@ -38,18 +36,18 @@
                         @SR.DeleteAccountParagraph3Html
                     </p>
                 </div>
-                <div class="js-delete-loader hide">
-                    <p class="lead text-center">
+                <div class="d-flex aligns-items-center justify-content-center js-delete-loader d-none">
+                    <p class="lead">
                         @SR.DeleteInProgressText
                     </p>
                     <p>
-                        <div class="center-block loader" aria-hidden="true"></div>
+                        <div class="loader" aria-hidden="true"></div>
                     </p>
                 </div>
             </div>
             <div class="modal-footer">
-                <form asp-route="@SiteRoutes.DeleteAccount" method="post" class="form-horizontal js-modal-form">
-                    <button type="button" class="btn btn-default js-delete-control" title="@SR.CancelButtonAltText" data-dismiss="modal" data-ga-label="Delete Account Cancel">@SR.CancelButtonText</button>
+                <form asp-route="@SiteRoutes.DeleteAccount" method="post" class="js-modal-form">
+                    <button type="button" class="btn btn-default js-delete-control" title="@SR.CancelButtonAltText" data-bs-dismiss="modal" data-ga-label="Delete Account Cancel">@SR.CancelButtonText</button>
                     <input type="submit" class="btn btn-danger disabled js-delete-control js-modal-confirm" value="@SR.DeleteAccountConfirmationButtonText" title="@SR.DeleteAccountConfirmationButtonAltText"  data-id="delete-account-confirm" data-ga-label="Delete Account Confirm" disabled />
                 </form>
             </div>

--- a/src/LondonTravel.Site/Views/Manage/_RemoveAccountLinkModal.cshtml
+++ b/src/LondonTravel.Site/Views/Manage/_RemoveAccountLinkModal.cshtml
@@ -2,15 +2,13 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="@SR.CloseButtonText" data-ga-label="Dismiss Remove Account Link">
-                    <span aria-hidden="true">&times;</span>
-                </button>
                 <h4 class="modal-title" id="remove-link-modal-title">@SR.RemoveAccountLinkModalTitle</h4>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="@SR.CloseButtonText" data-ga-label="Dismiss Remove Account Link"></button>
                 <div class="sr-only" id="remove-link-modal-description">@SR.RemoveAccountLinkModalDescription</div>
             </div>
-            <div class="modal-body">
+            <div class="modal-body d-flex aligns-items-center justify-content-center">
                 <p>
-                    <div class="center-block loader" aria-hidden="true"></div>
+                    <div class="loader" aria-hidden="true"></div>
                 </p>
             </div>
         </div>

--- a/src/LondonTravel.Site/Views/Manage/_RemoveAlexaLinkModal.cshtml
+++ b/src/LondonTravel.Site/Views/Manage/_RemoveAlexaLinkModal.cshtml
@@ -1,21 +1,19 @@
 @model ManageViewModel
 <noscript>
-    <form asp-route="@SiteRoutes.RemoveAlexaLink" method="post" class="form-horizontal">
+    <form asp-route="@SiteRoutes.RemoveAlexaLink" method="post">
         <input type="hidden" name="@(nameof(ManageViewModel.ETag))" value="@Model!.ETag" />
         <input type="submit" class="btn btn-default btn-sm" value="@SR.ManageUnlinkAlexaButtonText" title="@SR.ManageUnlinkAlexaButtonAltText" />
     </form>
 </noscript>
-<button class="btn btn-default btn-sm hide js-hidden-control" title="@SR.ManageUnlinkAlexaButtonAltText" data-id="remove-alexa-link" data-ga-label="Unlink Alexa Skill" data-toggle="modal" data-target="#unlink-alexa-modal">
+<button class="btn btn-default btn-sm d-none js-hidden-control" title="@SR.ManageUnlinkAlexaButtonAltText" data-id="remove-alexa-link" data-ga-label="Unlink Alexa Skill" data-bs-toggle="modal" data-bs-target="#unlink-alexa-modal">
     @SR.ManageUnlinkAlexaButtonText
 </button>
 <div id="unlink-alexa-modal" class="modal js-modal" data-id="modal-remove-alexa"  tabindex="-1" role="dialog" aria-describedby="unlink-alexa-modal-description" aria-labelledby="unlink-alexa-modal-title">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close js-unlink-content" data-dismiss="modal" aria-label="@SR.CloseButtonText" data-ga-label="Unlink Alexa Skill Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
                 <h4 class="modal-title" id="unlink-alexa-modal-title">@SR.ManageUnlinkAlexaModalTitle</h4>
+                <button type="button" class="btn-close js-unlink-content" data-bs-dismiss="modal" aria-label="@SR.CloseButtonText" data-ga-label="Unlink Alexa Skill Close"></button>
             </div>
             <div class="modal-body">
                 <div id="unlink-alexa-modal-description" class="js-unlink-content">
@@ -26,19 +24,19 @@
                         @SR.ManageUnlinkAlexaModalContent2
                     </p>
                 </div>
-                <div class="js-unlink-loader hide">
-                    <p class="lead text-center">
+                <div class=" d-flex aligns-items-center justify-content-center js-unlink-loader d-none">
+                    <p class="lead">
                         @SR.ManageUnlinkAlexaModalLoading
                     </p>
                     <p>
-                        <div class="center-block loader" aria-hidden="true"></div>
+                        <div class="loader" aria-hidden="true"></div>
                     </p>
                 </div>
             </div>
             <div class="modal-footer">
-                <form asp-route="@SiteRoutes.RemoveAlexaLink" method="post" class="form-horizontal js-modal-form">
+                <form asp-route="@SiteRoutes.RemoveAlexaLink" method="post" class="js-modal-form">
                     <input type="hidden" name="@(nameof(ManageViewModel.ETag))" value="@Model!.ETag" />
-                    <button type="button" class="btn btn-default js-unlink-control" title="@SR.CancelButtonAltText" data-dismiss="modal" data-ga-label="Unlink Alexa Skill Cancel">@SR.CancelButtonText</button>
+                    <button type="button" class="btn btn-default js-unlink-control" title="@SR.CancelButtonAltText" data-bs-dismiss="modal" data-ga-label="Unlink Alexa Skill Cancel">@SR.CancelButtonText</button>
                     <input type="submit" class="btn btn-danger disabled js-unlink-control js-modal-confirm" data-id="remove-alexa-confirm" value="@SR.ManageUnlinkAlexaModalConfirmButtonText" title="@SR.ManageUnlinkAlexaModalConfirmButtonAltText" data-ga-label="Unlink Alexa Skill Confirm" disabled />
                 </form>
             </div>

--- a/src/LondonTravel.Site/Views/Shared/_AccountLinkDenied.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_AccountLinkDenied.cshtml
@@ -1,9 +1,7 @@
 ﻿@if (string.Equals(Context.Request.Query["Message"].FirstOrDefault(), nameof(SiteMessage.LinkDenied), StringComparison.OrdinalIgnoreCase))
 {
     <div class="alert alert-warning" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Account Link Denied Dismiss">
-            <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Account Link Denied Dismiss"></button>
         <p class="lead">
             @SR.AccountLinkDeniedTitle
         </p>

--- a/src/LondonTravel.Site/Views/Shared/_AccountLinkFailed.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_AccountLinkFailed.cshtml
@@ -2,9 +2,7 @@
      string.Equals(Context.Request.Query["Message"].FirstOrDefault(), nameof(SiteMessage.Error), StringComparison.OrdinalIgnoreCase))
 {
     <div class="alert alert-warning" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Account Link Failed Dismiss">
-            <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Account Link Failed Dismiss"></button>
         <p class="lead">
             @SR.AccountLinkFailedTitle
         </p>

--- a/src/LondonTravel.Site/Views/Shared/_AlreadyRegistered.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_AlreadyRegistered.cshtml
@@ -1,9 +1,7 @@
 ﻿@if (string.Equals(ViewData["Message"] as string, nameof(SiteMessage.AlreadyRegistered), StringComparison.OrdinalIgnoreCase))
 {
     <div class="alert alert-warning" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Already Registered Dismiss">
-            <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Already Registered Dismiss"></button>
         <p class="lead">
             @SR.AlreadyRegisteredTitle
         </p>

--- a/src/LondonTravel.Site/Views/Shared/_Footer.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Footer.cshtml
@@ -1,41 +1,23 @@
 @model SiteOptions
 <hr />
 <footer>
-    <p class="hidden-sm hidden-xs">
+    <p>
         @SR.CopyrightText |
-        <a asp-page="@SiteRoutes.Help" title="@SR.HelpLinkAltText" data-ga-label="Help Footer">
+        <a class="text-nowrap" asp-page="@SiteRoutes.Help" title="@SR.HelpLinkAltText" data-ga-label="Help Footer">
             @SR.HelpLinkText
         </a>
         |
-        <a asp-page="@SiteRoutes.PrivacyPolicy" title="@SR.PrivacyPolicyLinkAltText" data-ga-label="Privacy Policy Footer">
+        <a class="text-nowrap" asp-page="@SiteRoutes.PrivacyPolicy" title="@SR.PrivacyPolicyLinkAltText" data-ga-label="Privacy Policy Footer">
             @SR.PrivacyPolicyLinkText
         </a>
         |
-        <a asp-page="@SiteRoutes.TermsOfService" title="@SR.TermsOfServiceLinkAltText" data-ga-label="Terms of Service Footer">
+        <a class="text-nowrap" asp-page="@SiteRoutes.TermsOfService" title="@SR.TermsOfServiceLinkAltText" data-ga-label="Terms of Service Footer">
             @SR.TermsOfServiceLinkText
         </a>
         |
-        <a asp-page="@SiteRoutes.Technology" title="@SR.TechnologyLinkAltText" data-ga-label="Technology Footer">
+        <a class="text-nowrap" asp-page="@SiteRoutes.Technology" title="@SR.TechnologyLinkAltText" data-ga-label="Technology Footer">
             @SR.TechnologyLinkText
         </a>
-        <span id="build-date" data-format="YYYY-MM-DD HH:mm Z" data-timestamp="@GitMetadata.Timestamp.ToString("u", CultureInfo.InvariantCulture)"></span>
+        <span id="build-date" class="d-none d-sm-inline" data-format="YYYY-MM-DD HH:mm Z" data-timestamp="@GitMetadata.Timestamp.ToString("u", CultureInfo.InvariantCulture)"></span>
     </p>
-    <div class="row hidden-md hidden-lg">
-        <div class="col-sm-12 col-xs-12">
-            @SR.CopyrightText
-        </div>
-        <div class="col-sm-12 col-xs-12">
-            <a asp-page="@SiteRoutes.Help" title="@SR.HelpLinkAltText" data-ga-label="Help Footer">
-                @SR.HelpLinkText
-            </a>
-            |
-            <a asp-page="@SiteRoutes.PrivacyPolicy" title="@SR.PrivacyPolicyLinkAltText" data-ga-label="Privacy Policy Footer">
-                @SR.PrivacyPolicyLinkText
-            </a>
-            |
-            <a asp-page="@SiteRoutes.TermsOfService" title="@SR.TermsOfServiceLinkAltText" data-ga-label="Terms of Service Footer">
-                @SR.TermsOfServiceLinkText
-            </a>
-        </div>
-    </div>
 </footer>

--- a/src/LondonTravel.Site/Views/Shared/_Layout.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Layout.cshtml
@@ -25,7 +25,6 @@
     @await Html.PartialAsync("_Links", Tuple.Create(canonicalUri, Options))
     @await RenderSectionAsync("links", required: false)
     @await RenderSectionAsync("meta", required: false)
-    @await Html.PartialAsync("_StylesHead")
     @await RenderSectionAsync("stylesHead", required: false)
     <script type="text/javascript" nonce="@Context.EnsureCspNonce()">
         @Html.Raw(JavaScriptSnippet.ScriptBody)

--- a/src/LondonTravel.Site/Views/Shared/_Links.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Links.cshtml
@@ -5,20 +5,20 @@
 }
     <link rel="dns-prefetch" href="https://@options?.ExternalLinks?.Cdn?.Host">
     <link rel="dns-prefetch" href="https://az416426.vo.msecnd.net">
+    <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
     <link rel="dns-prefetch" href="https://dc.services.visualstudio.com">
     <link rel="dns-prefetch" href="https://fonts.googleapis.com">
     <link rel="dns-prefetch" href="https://fonts.gstatic.com">
-    <link rel="dns-prefetch" href="https://stackpath.bootstrapcdn.com">
     <link rel="dns-prefetch" href="https://www.googletagmanager.com">
     <link rel="dns-prefetch" href="https://www.gravatar.com">
     <link rel="preconnect" href="https://@options?.ExternalLinks?.Cdn?.Host">
     <link rel="preconnect" href="https://az416426.vo.msecnd.net">
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <link rel="preconnect" href="https://cdnjs.cloudflare.com">
     <link rel="preconnect" href="https://dc.services.visualstudio.com">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link rel="preconnect" href="https://stackpath.bootstrapcdn.com">
     <link rel="preconnect" href="https://www.googletagmanager.com">
     <link rel="preconnect" href="https://www.gravatar.com">
     <link rel="canonical" href="@canonical">

--- a/src/LondonTravel.Site/Views/Shared/_Navbar.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Navbar.cshtml
@@ -1,72 +1,72 @@
-<nav class="navbar navbar-default navbar-fixed-top">
+<nav class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
     <div class="container">
-        <div class="navbar-header">
-            <a asp-page="@SiteRoutes.Home" class="navbar-brand" title="@SR.HomepageLinkAltText" data-ga-label="Homepage Navbar">
-                <span>
-                    @SR.BrandName
-                    <lazyimg src="@Url.CdnContent("avatar.png", Options)" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
-                    <noscript>
-                        <img src="@Url.CdnContent("avatar.png", Options)" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
-                    </noscript>
-                </span>
-            </a>
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse" data-ga-label="Navbar Collapse">
-                <span class="sr-only">@SR.NavbarCollapseAltText</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
-        </div>
-        <div class="navbar-collapse collapse">
-            <ul class="nav navbar-nav">
-                <li class="dropdown">
-                    <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" data-ga-label="Navbar Menu">
-                        @SR.NavbarMenuText <span class="caret"></span>
+        <a asp-page="@SiteRoutes.Home" class="navbar-brand" title="@SR.HomepageLinkAltText" data-ga-label="Homepage Navbar">
+            <span>
+                @SR.BrandName
+                <lazyimg src="@Url.CdnContent("avatar.png", Options)" class="pb-1" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
+                <noscript>
+                    <img src="@Url.CdnContent("avatar.png", Options)" class="pb-1" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
+                </noscript>
+            </span>
+        </a>
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbar-collapse" aria-expanded="false" aria-label="@SR.NavbarCollapseAltText">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="navbar-collapse collapse" id="navbar-collapse">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" id="navbar-dropdown" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" data-ga-label="Navbar Menu">
+                        @SR.NavbarMenuText
                     </a>
-                    <ul class="dropdown-menu">
+                    <ul class="dropdown-menu" aria-labelledby="navbar-dropdown">
                         <li>
-                            <a href="@Options?.ExternalLinks?.Skill" rel="noopener noreferrer" target="_blank" title="@SR.InstallLinkAltText" data-ga-label="Install Navbar">
+                            <a class="dropdown-item" href="@Options?.ExternalLinks?.Skill" rel="noopener noreferrer" target="_blank" title="@SR.InstallLinkAltText" data-ga-label="Install Navbar">
                                 @SR.InstallLinkText
-                                <i class="fa fa-external-link" aria-hidden="true"></i>
+                                <span class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></span>
                             </a>
                         </li>
                         @if (Options?.Authentication?.IsEnabled == true)
                         {
-                            <li role="separator" class="divider"></li>
+                            <li><hr class="dropdown-divider"></li>
                             @if (User?.Identity?.IsAuthenticated == true)
                             {
                                 <li>
-                                    <a asp-route="@SiteRoutes.Manage" title="@SR.ManageLinkAltText" data-ga-label="Manage Account Navbar">
-                                        @SR.ManageLinkText <i class="fa fa-user" aria-hidden="true"></i>
+                                    <a class="dropdown-item" asp-route="@SiteRoutes.Manage" title="@SR.ManageLinkAltText" data-ga-label="Manage Account Navbar">
+                                        @SR.ManageLinkText
+                                        <span class="fa-solid fa-user" aria-hidden="true"></span>
                                     </a>
                                 </li>
                             }
                             else
                             {
                                 <li>
-                                    <a asp-page="@SiteRoutes.Register" title="@SR.RegisterLinkAltText" data-ga-label="Register Navbar">@SR.RegisterLinkText <i class="fa fa-user-plus" aria-hidden="true"></i></a>
+                                    <a class="dropdown-item" asp-page="@SiteRoutes.Register" title="@SR.RegisterLinkAltText" data-ga-label="Register Navbar">
+                                        @SR.RegisterLinkText
+                                        <span class="fa-solid fa-user-plus" aria-hidden="true"></span>
+                                    </a>
                                 </li>
                             }
                         }
-                        <li role="separator" class="divider"></li>
+                        <li><hr class="dropdown-divider"></li>
                         <li>
-                            <a asp-page="@SiteRoutes.Help" title="@SR.HelpLinkAltText" data-ga-label="Help Navbar">
-                                @SR.HelpLinkText <i class="fa fa-question-circle" aria-hidden="true"></i>
+                            <a class="dropdown-item" asp-page="@SiteRoutes.Help" title="@SR.HelpLinkAltText" data-ga-label="Help Navbar">
+                                @SR.HelpLinkText
+                                <span class="fa-solid fa-circle-question" aria-hidden="true"></span>
                             </a>
                         </li>
                         <li>
-                            <a asp-page="@SiteRoutes.PrivacyPolicy" title="@SR.PrivacyPolicyLinkAltText" data-ga-label="Privacy Policy Navbar">
+                            <a class="dropdown-item" asp-page="@SiteRoutes.PrivacyPolicy" title="@SR.PrivacyPolicyLinkAltText" data-ga-label="Privacy Policy Navbar">
                                 @SR.PrivacyPolicyLinkText
                             </a>
                         </li>
                         <li>
-                            <a asp-page="@SiteRoutes.TermsOfService" title="@SR.TermsOfServiceLinkAltText" data-ga-label="Terms of Service Navbar">
+                            <a class="dropdown-item" asp-page="@SiteRoutes.TermsOfService" title="@SR.TermsOfServiceLinkAltText" data-ga-label="Terms of Service Navbar">
                                 @SR.TermsOfServiceLinkText
                             </a>
                         </li>
-                        <li role="separator" class="divider"></li>
+                        <li><hr class="dropdown-divider"></li>
                         <li>
-                            <a asp-page="@SiteRoutes.Technology" title="@SR.TechnologyLinkAltText" data-ga-label="Technology Navbar">
+                            <a class="dropdown-item" asp-page="@SiteRoutes.Technology" title="@SR.TechnologyLinkAltText" data-ga-label="Technology Navbar">
                                 @SR.TechnologyLinkText
                             </a>
                         </li>

--- a/src/LondonTravel.Site/Views/Shared/_PermissionDenied.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_PermissionDenied.cshtml
@@ -1,9 +1,7 @@
 ﻿@if (string.Equals(ViewData["Message"] as string, nameof(SiteMessage.PermissionDenied), StringComparison.OrdinalIgnoreCase))
 {
     <div class="alert alert-warning" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Permission Denied Dismiss">
-            <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="@SR.CloseButtonText" data-ga-label="Permission Denied Dismiss"></button>
         <p class="lead">
             @SR.PermissionDeniedTitle
         </p>

--- a/src/LondonTravel.Site/Views/Shared/_Scripts.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Scripts.cshtml
@@ -1,10 +1,10 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.min.js" integrity="sha512-jNDtFf7qgU0eH/+Z42FG4fw3w7DM/9zbgNPe3wfJlCylVDTT3IgKW5r92Vy9IHa6U50vyMz5gRByIu4YIXFtaQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.3/moment.min.js" integrity="sha512-dGM81hdEjiW5IomkknOx3fIfwij3c7xwh6TcrbumlkHJtO81OKNjLISJaPEhCgVxM6+0uGJ7KRmI2YJFn0AmHQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js" integrity="sha512-+H4iLjY3JsKiF2V6N366in5IQHj2uEsGV7Pp/GRcm0fn76aPAk5V8xB6n8fQhhSonTqTXs/klFz4D0GIn6Br9g==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
 @if (string.Equals(CultureInfo.CurrentUICulture.Name, "en-GB", StringComparison.Ordinal))
 {
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.3/locale/en-gb.min.js" integrity="sha512-w+tDY4gx49+DNVlN7Nmc9ldOkh6nP3w4txBTEatSx3XrZdfYtX9+oylJjQ7RqeeDzDebG3u1VAg/gM5Td2Bd5Q==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/locale/en-gb.min.js" integrity="sha512-w+tDY4gx49+DNVlN7Nmc9ldOkh6nP3w4txBTEatSx3XrZdfYtX9+oylJjQ7RqeeDzDebG3u1VAg/gM5Td2Bd5Q==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
 }
 @{
     var analyticsId = Options.Analytics?.Google;

--- a/src/LondonTravel.Site/Views/Shared/_SignInForm.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_SignInForm.cshtml
@@ -14,13 +14,11 @@
             .ToList();
     }
 }
-<form asp-route="@SiteRoutes.ExternalSignIn" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" class="form-horizontal">
-    <div>
-        <p>
-            @foreach (var scheme in schemes)
-            {
-                @await Html.PartialAsync("_SocialButton", scheme)
-            }
-        </p>
+<form asp-route="@SiteRoutes.ExternalSignIn" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post">
+    <div class="vstack gap-2">
+        @foreach (var scheme in schemes)
+        {
+            @await Html.PartialAsync("_SocialButton", scheme)
+        }
     </div>
 </form>

--- a/src/LondonTravel.Site/Views/Shared/_SignInModal.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_SignInModal.cshtml
@@ -2,15 +2,13 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="@SR.CloseButtonText" data-ga-label="Sign-In Dismiss">
-                    <span aria-hidden="true">&times;</span>
-                </button>
                 <h4 class="modal-title" id="sign-in-modal-title">@SR.SigningInModalTitle</h4>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="@SR.CloseButtonText" data-ga-label="Sign-In Dismiss"></button>
                 <div class="sr-only" id="sign-in-modal-description">@SR.SigningInModalDescription</div>
             </div>
-            <div class="modal-body">
+            <div class="modal-body d-flex aligns-items-center justify-content-center">
                 <p>
-                    <div class="center-block loader" aria-hidden="true"></div>
+                    <div class="loader" aria-hidden="true"></div>
                 </p>
             </div>
         </div>

--- a/src/LondonTravel.Site/Views/Shared/_SignInPartial.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_SignInPartial.cshtml
@@ -5,10 +5,10 @@
 }
 @if (SignInManager.IsSignedIn(User))
 {
-    <form asp-route="@SiteRoutes.SignOut" method="post" class="navbar-right">
+    <form asp-route="@SiteRoutes.SignOut" method="post">
         <ul class="nav navbar-nav navbar-right">
             <li>
-                <a asp-route="@SiteRoutes.Manage" title="@SR.ManageLinkAltText" data-ga-label="Manage Account Navbar">
+                <a class="nav-link" asp-route="@SiteRoutes.Manage" title="@SR.ManageLinkAltText" data-ga-label="Manage Account Navbar">
                     <span data-id="user-name">@displayName</span>
                     <lazyimg alt="@displayName" title="@displayName" src="@avatarUrl" aria-hidden="true" />
                     <noscript>
@@ -17,9 +17,9 @@
                 </a>
             </li>
             <li>
-                <button type="submit" class="btn btn-link navbar-btn navbar-link" title="@SR.SignOutLinkText" data-id="sign-out" data-ga-label="Sign-Out Navbar">
+                <button type="submit" class="btn btn-link navbar-btn nav-link" title="@SR.SignOutLinkText" data-id="sign-out" data-ga-label="Sign-Out Navbar">
                     @SR.SignOutLinkText
-                    <i class="fa fa-sign-out" aria-hidden="true"></i>
+                    <span class="fa-solid fa-right-from-bracket" aria-hidden="true"></span>
                 </button>
             </li>
         </ul>
@@ -28,7 +28,15 @@
 else
 {
     <ul class="nav navbar-nav navbar-right">
-        <li><a asp-route="@SiteRoutes.SignIn" rel="nofollow" title="@SR.SignInLinkAltText" data-ga-label="Sign-In Navbar">@SR.SignInLinkText</a></li>
-        <li><a asp-page="@SiteRoutes.Register" title="@SR.RegisterLinkAltText" data-ga-label="Register Navbar">@SR.RegisterLinkText</a></li>
+        <li>
+            <a class="nav-link" asp-route="@SiteRoutes.SignIn" rel="nofollow" title="@SR.SignInLinkAltText" data-ga-label="Sign-In Navbar">
+                @SR.SignInLinkText
+            </a>
+        </li>
+        <li>
+            <a class="nav-link" asp-page="@SiteRoutes.Register" title="@SR.RegisterLinkAltText" data-ga-label="Register Navbar">
+                @SR.RegisterLinkText
+            </a>
+        </li>
     </ul>
 }

--- a/src/LondonTravel.Site/Views/Shared/_SocialButton.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_SocialButton.cshtml
@@ -1,13 +1,13 @@
 @model Microsoft.AspNetCore.Authentication.AuthenticationScheme
 <button type="submit"
-        class="btn btn-block btn-social @Html.GetSocialLoginButtonCss(Model!.Name)"
+        class="btn btn-lg btn-primary btn-social @Html.GetSocialLoginButtonCss(Model!.Name)"
         name="provider"
         value="@Model.Name"
         title="@SR.SignInButtonAltText(Model.DisplayName!)"
         data-id="sign-in-@Model.Name.ToLowerInvariant()"
         data-ga-label="Sign-In - @Model.DisplayName"
-        data-target=".sign-in-modal"
-        data-toggle="modal">
+        data-bs-target=".sign-in-modal"
+        data-bs-toggle="modal">
     @await Html.PartialAsync("_SocialIcon", Model.Name)
     @SR.SignInButtonText(Model.DisplayName!)
 </button>

--- a/src/LondonTravel.Site/Views/Shared/_SocialIcon.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_SocialIcon.cshtml
@@ -1,2 +1,2 @@
-﻿@model string
-<i class="fa @Html.GetSocialLoginIconCss(Model!)" aria-hidden="true"></i>
+@model string
+<span class="fa-brands @(Html.GetSocialLoginIconCss(Model!)) mt-1" aria-hidden="true"></span>

--- a/src/LondonTravel.Site/Views/Shared/_StylesBody.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_StylesBody.cshtml
@@ -1,5 +1,5 @@
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootswatch/3.4.1/flatly/bootstrap.min.css" integrity="sha384-bfWZLPtvQKHg/nZNhaO/ZW4Ba8ISud5CtEjnCTU6OR1yOq5zrrF+JP2o7om6rzLf" crossorigin="anonymous">
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.1.3/dist/flatly/bootstrap.min.css" integrity="sha384-JJl14kOPjuUj+o0fDTJGBSCDKpu1A4BuCmARIetHUvTVmopvVZITFd4AhRMJIlz7" crossorigin="anonymous" referrerpolicy="no-referrer">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous" referrerpolicy="no-referrer">
 <environment names="Development">
     <link rel="stylesheet" href="~/assets/css/site.css" asp-append-version="true" asp-csp-nonce="@Context.EnsureCspNonce()" asp-inline="true" asp-minify-inlined="true">
 </environment>

--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -114,13 +114,11 @@
         "www.google-analytics.com",
         "www.googletagmanager.com"
       ],
-      "default-src": [
-        "stackpath.bootstrapcdn.com"
-      ],
+      "default-src": [],
       "font-src": [
+        "cdnjs.cloudflare.com",
         "fonts.googleapis.com",
-        "fonts.gstatic.com",
-        "stackpath.bootstrapcdn.com"
+        "fonts.gstatic.com"
       ],
       "form-action": [
         "accounts.google.com",
@@ -146,14 +144,14 @@
       "object-src": [],
       "script-src": [
         "az416426.vo.msecnd.net",
+        "cdn.jsdelivr.net",
         "cdnjs.cloudflare.com",
-        "stackpath.bootstrapcdn.com",
         "www.googletagmanager.com"
       ],
       "style-src": [
+        "cdn.jsdelivr.net",
         "cdnjs.cloudflare.com",
-        "fonts.googleapis.com",
-        "stackpath.bootstrapcdn.com"
+        "fonts.googleapis.com"
       ]
     },
     "ExternalLinks": {

--- a/src/LondonTravel.Site/assets/scripts/ts/Swagger.ts
+++ b/src/LondonTravel.Site/assets/scripts/ts/Swagger.ts
@@ -42,7 +42,6 @@ window.onload = () => {
                 // Delete overly-verbose headers from the UI
                 delete response.headers["content-security-policy"];
                 delete response.headers["content-security-policy-report-only"];
-                delete response.headers["feature-policy"];
                 delete response.headers["permissions-policy"];
             }
         });

--- a/src/LondonTravel.Site/assets/scripts/ts/martinCostello/londonTravel/Manage.ts
+++ b/src/LondonTravel.Site/assets/scripts/ts/martinCostello/londonTravel/Manage.ts
@@ -24,7 +24,7 @@ namespace martinCostello.londonTravel {
         public initialize(): void {
             $(".js-hidden-control")
                 .fadeIn()
-                .removeClass("hide");
+                .removeClass("d-none");
             $(".js-modal-form").on("submit", this.onFormSubmit);
             $(".js-modal").on("show.bs.modal", this.onModalShown);
         }
@@ -36,8 +36,8 @@ namespace martinCostello.londonTravel {
         private onFormSubmit = (e: JQuery.TriggeredEvent): void => {
             const form = $(e.target);
             form.find(".js-delete-control").addClass("disabled");
-            form.find(".js-delete-content").addClass("hide");
-            form.find(".js-delete-loader").removeClass("hide");
+            form.find(".js-delete-content").addClass("d-none");
+            form.find(".js-delete-loader").removeClass("d-none");
         }
 
         /**

--- a/src/LondonTravel.Site/assets/scripts/ts/martinCostello/londonTravel/Preferences.ts
+++ b/src/LondonTravel.Site/assets/scripts/ts/martinCostello/londonTravel/Preferences.ts
@@ -29,8 +29,8 @@ namespace martinCostello.londonTravel {
             this.resetButton = this.container.find(".js-preferences-reset");
             this.saveButton = this.container.find(".js-preferences-save");
 
-            this.favoritesCount = this.container.find(".js-favorites-count").removeClass("hide");
-            this.otherCount = this.container.find(".js-other-count").removeClass("hide");
+            this.favoritesCount = this.container.find(".js-favorites-count").removeClass("d-none");
+            this.otherCount = this.container.find(".js-other-count").removeClass("d-none");
 
             // Treat entire div as a button
             this.container
@@ -42,7 +42,7 @@ namespace martinCostello.londonTravel {
                 .on("click", this.resetFavoriteLines)
                 .addClass("disabled")
                 .prop("disabled", true)
-                .removeClass("hide");
+                .removeClass("d-none");
 
             // Disable the clear button if everything is currently deselected
             if (this.initialState === "") {
@@ -54,7 +54,7 @@ namespace martinCostello.londonTravel {
             // Add handler for clearing the selections and show the button
             this.clearButton
                 .on("click", this.clearFavoriteLines)
-                .removeClass("hide");
+                .removeClass("d-none");
 
             // Disable the save button the state is different
             this.saveButton
@@ -122,7 +122,7 @@ namespace martinCostello.londonTravel {
             const ids: string[] = [];
 
             this.getSelectedCheckboxes()
-                .each((index: number, elem: Element) => {
+                .each((_: number, elem: Element) => {
                     const element = $(elem);
                     ids.push(element.attr("data-line-id"));
                 });
@@ -161,7 +161,7 @@ namespace martinCostello.londonTravel {
             const ids: string[] = this.initialState.split(",");
 
             this.getAllCheckboxes()
-                .each((index: number, elem: Element) => {
+                .each((_: number, elem: Element) => {
                     const element = $(elem);
                     const id: string = element.attr("data-line-id");
                     element.prop("checked", ids.indexOf(id) > -1);
@@ -186,5 +186,5 @@ namespace martinCostello.londonTravel {
     }
 }
 (() => {
-    const preferences: martinCostello.londonTravel.Preferences = new martinCostello.londonTravel.Preferences();
+    const _ = new martinCostello.londonTravel.Preferences();
 })();

--- a/src/LondonTravel.Site/assets/styles/css/site.css
+++ b/src/LondonTravel.Site/assets/styles/css/site.css
@@ -4,11 +4,7 @@
 */
 
 body {
-    padding-top: 70px;
-}
-
-.btn-wrapper {
-    margin-bottom: 5px;
+    padding-top: 85px;
 }
 
 .btn-amazon {
@@ -18,11 +14,19 @@ body {
     color: #fff;
 }
 
+.btn-amazon:hover {
+    background-color: #E08802;
+}
+
 .btn-apple {
     background-color: black;
     border-color: rgb(0,0,0);
     border-color: rgba(0,0,0,0.2);
     color: #fff;
+}
+
+.btn-close {
+    float: right;
 }
 
 /* csslint ignore:start */

--- a/src/LondonTravel.Site/assets/styles/css/travel.css
+++ b/src/LondonTravel.Site/assets/styles/css/travel.css
@@ -4,72 +4,154 @@
 */
 
 .travel-line {
-    border: 1px solid #eee;
     border-left-color: #2070B0;
-    border-left-width: 15px;
-    border-radius: 3px;
+    border-left-style: solid;
+    border-left-width: 10px;
     cursor: pointer;
-    padding: 20px;
+}
+
+.travel-line,
+.list-group-item:first-child,
+.list-group-item:first-child,
+.list-group-item:last-child,
+.list-group-item:last-child {
+    border-radius: 5px 1px 1px 5px;
 }
 
 .travel-line-bakerloo {
     border-left-color: #894e24;
 }
 
+.travel-line-bakerloo > .form-check-input:checked {
+    background-color: #894e24;
+    border-color: #894e24;
+}
+
 .travel-line-central {
     border-left-color: #dc241f;
+}
+
+.travel-line-central > .form-check-input:checked {
+    background-color: #dc241f;
+    border-color: #dc241f;
 }
 
 .travel-line-circle {
     border-left-color: #ffce00;
 }
 
+.travel-line-circle > .form-check-input:checked {
+    background-color: #ffce00;
+    border-color: #ffce00;
+}
+
 .travel-line-district {
     border-left-color: #007229;
+}
+
+.travel-line-district > .form-check-input:checked {
+    background-color: #007229;
+    border-color: #007229;
 }
 
 .travel-line-dlr {
     border-left-color: #00afad;
 }
 
+.travel-line-dlr > .form-check-input:checked {
+    background-color: #00afad;
+    border-color: #00afad;
+}
+
 .travel-line-elizabeth {
     border-left-color: #6950a1;
+}
+
+.travel-line-elizabeth > .form-check-input:checked {
+    background-color: #6950a1;
+    border-color: #6950a1;
 }
 
 .travel-line-hammersmith-city {
     border-left-color: #d799af;
 }
 
+.travel-line-hammersmith-city > .form-check-input:checked {
+    background-color: #d799af;
+    border-color: #d799af;
+}
+
 .travel-line-jubilee {
     border-left-color: #6a7278;
+}
+
+.travel-line-jubilee > .form-check-input:checked {
+    background-color: #6a7278;
+    border-color: #6a7278;
 }
 
 .travel-line-london-overground {
     border-left-color: #e86a10;
 }
 
+.travel-line-london-overground > .form-check-input:checked {
+    background-color: #e86a10;
+    border-color: #e86a10;
+}
+
 .travel-line-metropolitan {
     border-left-color: #751056;
+}
+
+.travel-line-metropolitan > .form-check-input:checked {
+    background-color: #751056;
+    border-color: #751056;
 }
 
 .travel-line-northern {
     border-left-color: #000;
 }
 
+.travel-line-northern > .form-check-input:checked {
+    background-color: #000;
+    border-color: #000;
+}
+
 .travel-line-piccadilly, .travel-line-tfl-rail {
     border-left-color: #0019a8;
+}
+
+.travel-line-piccadilly > .form-check-input:checked,
+.travel-line-tfl-rail > .form-check-input:checked {
+    background-color: #0019a8;
+    border-color: #0019a8;
 }
 
 .travel-line-tram {
     border-left-color: #6c0;
 }
 
+.travel-line-tram > .form-check-input:checked {
+    background-color: #6c0;
+    border-color: #6c0;
+}
+
 .travel-line-victoria {
     border-left-color: #00a0e2;
 }
 
+.travel-line-victoria > .form-check-input:checked {
+    background-color: #00a0e2;
+    border-color: #00a0e2;
+}
+
 .travel-line-waterloo-city {
     border-left-color: #76d0bd;
+}
+
+.travel-line-waterloo-city > .form-check-input:checked {
+    background-color: #76d0bd;
+    border-color: #76d0bd;
 }
 
 .checkbox label:after {

--- a/src/LondonTravel.Site/gulpfile.js
+++ b/src/LondonTravel.Site/gulpfile.js
@@ -1,4 +1,4 @@
-/// <binding Clean='clean' ProjectOpened='publish, watch' />
+/// <binding ProjectOpened='publish, watch' />
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 

--- a/src/LondonTravel.Site/wwwroot/bad-request.html
+++ b/src/LondonTravel.Site/wwwroot/bad-request.html
@@ -2,7 +2,7 @@
 <html lang="en-gb">
 <head>
     <meta charset="utf-8" />
-    <title>Error - London Travel</title>
+    <title>Bad Request - London Travel</title>
     <meta name="language" content="en" />
     <meta name="referrer" content="no-referrer-when-downgrade" />
     <meta name="robots" content="NOINDEX" />
@@ -28,12 +28,11 @@
         <hr />
         <footer>
             <p>
-                &copy; Martin Costello 2019
+                &copy; Martin Costello 2022
             </p>
         </footer>
     </div>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootswatch/3.4.1/flatly/bootstrap.min.css" integrity="sha384-bfWZLPtvQKHg/nZNhaO/ZW4Ba8ISud5CtEjnCTU6OR1yOq5zrrF+JP2o7om6rzLf" crossorigin="anonymous">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous" defer></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.1.3/dist/flatly/bootstrap.min.css" integrity="sha384-JJl14kOPjuUj+o0fDTJGBSCDKpu1A4BuCmARIetHUvTVmopvVZITFd4AhRMJIlz7" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </body>
 </html>

--- a/src/LondonTravel.Site/wwwroot/error.html
+++ b/src/LondonTravel.Site/wwwroot/error.html
@@ -28,12 +28,11 @@
         <hr />
         <footer>
             <p>
-                &copy; Martin Costello 2019
+                &copy; Martin Costello 2022
             </p>
         </footer>
     </div>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootswatch/3.4.1/flatly/bootstrap.min.css" integrity="sha384-bfWZLPtvQKHg/nZNhaO/ZW4Ba8ISud5CtEjnCTU6OR1yOq5zrrF+JP2o7om6rzLf" crossorigin="anonymous">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous" defer></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.1.3/dist/flatly/bootstrap.min.css" integrity="sha384-JJl14kOPjuUj+o0fDTJGBSCDKpu1A4BuCmARIetHUvTVmopvVZITFd4AhRMJIlz7" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </body>
 </html>

--- a/src/LondonTravel.Site/wwwroot/not-found.html
+++ b/src/LondonTravel.Site/wwwroot/not-found.html
@@ -2,7 +2,7 @@
 <html lang="en-gb">
 <head>
     <meta charset="utf-8" />
-    <title>Error - London Travel</title>
+    <title>Not Found - London Travel</title>
     <meta name="language" content="en" />
     <meta name="referrer" content="no-referrer-when-downgrade" />
     <meta name="robots" content="NOINDEX" />
@@ -28,12 +28,11 @@
         <hr />
         <footer>
             <p>
-                &copy; Martin Costello 2019
+                &copy; Martin Costello 2022
             </p>
         </footer>
     </div>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootswatch/3.4.1/flatly/bootstrap.min.css" integrity="sha384-bfWZLPtvQKHg/nZNhaO/ZW4Ba8ISud5CtEjnCTU6OR1yOq5zrrF+JP2o7om6rzLf" crossorigin="anonymous">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous" defer></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.1.3/dist/flatly/bootstrap.min.css" integrity="sha384-JJl14kOPjuUj+o0fDTJGBSCDKpu1A4BuCmARIetHUvTVmopvVZITFd4AhRMJIlz7" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </body>
 </html>

--- a/tests/LondonTravel.Site.Tests/EndToEnd/ResourceTests.cs
+++ b/tests/LondonTravel.Site.Tests/EndToEnd/ResourceTests.cs
@@ -83,7 +83,6 @@ public class ResourceTests
         {
             "content-security-policy",
             "content-security-policy-report-only",
-            "feature-policy",
             "NEL",
             "Permissions-Policy",
             "Referrer-Policy",

--- a/tests/LondonTravel.Site.Tests/Integration/ResourceTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/ResourceTests.cs
@@ -138,7 +138,6 @@ public class ResourceTests : IntegrationTest
         {
             "content-security-policy",
             "content-security-policy-report-only",
-            "feature-policy",
             "NEL",
             "Permissions-Policy",
             "Referrer-Policy",

--- a/tests/LondonTravel.Site.Tests/Pages/LinkedAccount.cs
+++ b/tests/LondonTravel.Site.Tests/Pages/LinkedAccount.cs
@@ -22,7 +22,7 @@ public sealed class LinkedAccount
 
     public async Task<string> NameAsync()
     {
-        IElementHandle? element = await RootElement.QuerySelectorAsync("span");
+        IElementHandle? element = await RootElement.QuerySelectorAsync("span[class='brand-name']");
         string text = await element!.InnerTextAsync();
         return text.Trim();
     }

--- a/tests/LondonTravel.Site.Tests/Pages/ModalBase.cs
+++ b/tests/LondonTravel.Site.Tests/Pages/ModalBase.cs
@@ -22,7 +22,7 @@ public abstract class ModalBase
     protected async Task CloseSelfAsync()
     {
         IElementHandle? modal = await Navigator.Page.QuerySelectorAsync(DialogSelector);
-        IElementHandle? dismiss = await modal!.QuerySelectorAsync("[data-dismiss='modal']");
+        IElementHandle? dismiss = await modal!.QuerySelectorAsync("[data-bs-dismiss='modal']");
 
         await dismiss!.ClickAsync();
     }


### PR DESCRIPTION
- Update from Bootstrap 3 to Bootstrap 5.
- Fix some TypeScript warnings.
- Remove Feature-Policy HTTP response header.
- Add missing hover colour to Amazon sign in button.
- Remove binding to clean JS/CSS on C# clean.
- Use `<span>` instead of `<i>` for icons.
- Use `<em>` instead of `<i>` for italics.
- Update to Swagger UI 4.12.0.
- Update to moment.js 2.29.4.
- Update to FontAwesome 6.0.0.
- Remove empty partials.
- Update the technology list.
- Update static copyright years.
- Fix error page titles.

Resolves #184.