### PR TITLE
Fix CSP error

### DIFF
--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -109,6 +109,7 @@
       "connect-src": [
         "dc.services.visualstudio.com",
         "eastus-1.in.applicationinsights.azure.com",
+        "northeurope-0.in.applicationinsights.azure.com",
         "region1.google-analytics.com",
         "stats.g.doubleclick.net",
         "www.google-analytics.com",


### PR DESCRIPTION
Add Application Insights hostname for North Europe to fix CSP error.
