### PR TITLE
Add workflow to update static assets

### DIFF
--- a/.github/workflows/update-static-assets.yml
+++ b/.github/workflows/update-static-assets.yml
@@ -1,0 +1,25 @@
+name: update-static-assets
+
+on:
+  schedule:
+    - cron:  '0 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-static-assets:
+    name: Update static assets
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Update static assets
+      uses: martincostello/update-static-assets@main
+      if: ${{ github.repository_owner == 'martincostello' }}
+      with:
+        labels: "dependencies"
+        repo-token: ${{ secrets.ACCESS_TOKEN }}
+        user-email: 102549341+costellobot@users.noreply.github.com
+        user-name: costellobot


### PR DESCRIPTION
Add a workflow to keep static CDN asserts up-to-date using [update-static-assets](https://github.com/martincostello/update-static-assets).
