### PR TITLE
Remove MicrosoftAspNetCoreVersion

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
     <AspNetSecurityOAuthVersion>7.0.0</AspNetSecurityOAuthVersion>
-    <MicrosoftAspNetCoreVersion>7.0.3</MicrosoftAspNetCoreVersion>
     <NodaTimeVersion>3.1.6</NodaTimeVersion>
     <SwashbuckleAspNetCoreVersion>6.5.0</SwashbuckleAspNetCoreVersion>
   </PropertyGroup>


### PR DESCRIPTION
Remove the `MicrosoftAspNetCoreVersion` MSBuild property as it's redundant with the new workflow to update the .NET SDK.
