### PR TITLE
.NET 8 preparation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
       if: ${{ runner.os == 'Windows' && success() }}
       with:
         name: webapp
-        path: ./.artifacts/publish
+        path: ./artifacts/publish
         if-no-files-found: error
 
     - name: Publish screenshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ env:
   APPLICATION_URL_DEV: https://londontravel-dev.martincostello.com
   APPLICATION_URL_PROD: https://londontravel.martincostello.com
   AZURE_WEBAPP_NAME: londontravelmartincostello
-  AZURE_WEBAPP_PACKAGE_PATH: ./artifacts/publish
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false
   DOTNET_MULTILEVEL_LOOKUP: 0
@@ -24,6 +23,7 @@ env:
   DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
   FORCE_COLOR: 1
   NUGET_XMLDOC_MODE: skip
+  PUBLISH_RUNTIME: win10-x64
   TERM: xterm
 
 permissions:
@@ -90,7 +90,7 @@ jobs:
 
     - name: Build, test and publish
       shell: pwsh
-      run: ./build.ps1 -Runtime win10-x64
+      run: ./build.ps1 -Runtime "${{ env.PUBLISH_RUNTIME }}"
 
     - uses: codecov/codecov-action@40a12dcee2df644d47232dde008099a3e9e4f865 # v3.1.2
       name: Upload coverage to Codecov
@@ -100,10 +100,11 @@ jobs:
 
     - name: Publish artifacts
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-      if: ${{ runner.os == 'Windows' }}
+      if: ${{ runner.os == 'Windows' && success() }}
       with:
         name: webapp
-        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+        path: ./.artifacts/publish
+        if-no-files-found: error
 
     - name: Publish screenshots
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -87,3 +87,4 @@ jobs:
       with:
         name: lighthouse
         path: ${{ github.workspace }}/artifacts
+        if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-﻿.DS_Store
+﻿.artifacts
+.DS_Store
 .dockershare
 .dotnetcli
 .metadata

--- a/build.ps1
+++ b/build.ps1
@@ -1,7 +1,6 @@
 #! /usr/bin/env pwsh
 param(
     [Parameter(Mandatory = $false)][string] $Configuration = "Release",
-    [Parameter(Mandatory = $false)][string] $VersionSuffix = "",
     [Parameter(Mandatory = $false)][string] $OutputPath = "",
     [Parameter(Mandatory = $false)][switch] $SkipTests,
     [Parameter(Mandatory = $false)][string] $Runtime = ""
@@ -22,7 +21,7 @@ if ($OutputPath -eq "") {
 $installDotNetSdk = $false;
 
 if (($null -eq (Get-Command "dotnet" -ErrorAction SilentlyContinue)) -and ($null -eq (Get-Command "dotnet.exe" -ErrorAction SilentlyContinue))) {
-    Write-Host "The .NET Core SDK is not installed."
+    Write-Host "The .NET SDK is not installed."
     $installDotNetSdk = $true
 }
 else {
@@ -34,7 +33,7 @@ else {
     }
 
     if ($installedDotNetVersion -ne $dotnetVersion) {
-        Write-Host "The required version of the .NET Core SDK is not installed. Expected $dotnetVersion."
+        Write-Host "The required version of the .NET SDK is not installed. Expected $dotnetVersion."
         $installDotNetSdk = $true
     }
 }
@@ -101,11 +100,6 @@ function DotNetPublish {
         $additionalArgs += "--self-contained"
         $additionalArgs += "--runtime"
         $additionalArgs += $Runtime
-    }
-
-    if (![string]::IsNullOrEmpty($VersionSuffix)) {
-        $additionalArgs += "--version-suffix"
-        $additionalArgs += $VersionSuffix
     }
 
     & $dotnet publish $Project --output $publishPath --configuration $Configuration $additionalArgs

--- a/tests/LondonTravel.Site.Tests/BrowserFixture.cs
+++ b/tests/LondonTravel.Site.Tests/BrowserFixture.cs
@@ -9,6 +9,7 @@ namespace MartinCostello.LondonTravel.Site;
 public class BrowserFixture
 {
     private const string VideosDirectory = "videos";
+    private const string AssetsDirectory = ".";
 
     public BrowserFixture(
         BrowserFixtureOptions options,
@@ -66,7 +67,7 @@ public class BrowserFixture
             if (Options.CaptureTrace)
             {
                 string traceName = GenerateFileName(activeTestName, ".zip");
-                string path = Path.Combine("traces", traceName);
+                string path = Path.Combine(AssetsDirectory, "traces", traceName);
 
                 await context.Tracing.StopAsync(new() { Path = path });
 
@@ -139,7 +140,7 @@ public class BrowserFixture
         try
         {
             string fileName = GenerateFileName(testName, ".png");
-            string path = Path.Combine("screenshots", fileName);
+            string path = Path.Combine(AssetsDirectory, "screenshots", fileName);
 
             await page.ScreenshotAsync(new() { Path = path });
 
@@ -161,7 +162,7 @@ public class BrowserFixture
         try
         {
             string fileName = GenerateFileName(testName, ".webm");
-            string path = Path.Combine(VideosDirectory, fileName);
+            string path = Path.Combine(AssetsDirectory, VideosDirectory, fileName);
 
             await page.CloseAsync();
             await page.Video.SaveAsAsync(path);


### PR DESCRIPTION
Port changes from #1549 to minimise differences:
- Remove some environment variables from build scripts.
- Fail build if certain artifacts cannot be found.
- Ignore missing lighthouse artifacts.
