### PR TITLE
Remove redundant suppression

### DIFF
--- a/src/LondonTravel.Site/Program.cs
+++ b/src/LondonTravel.Site/Program.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1852
-
 using System.IO.Compression;
 using System.Text.Json.Serialization.Metadata;
 using MartinCostello.LondonTravel.Site;


### PR DESCRIPTION
Remove now-redundant suppression for false-positive code analysis warning.
