### PR TITLE
.NET 8 preparation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,7 +52,6 @@
     <CollectCoverage Condition=" '$(WEBSITE_URL)' == '' ">true</CollectCoverage>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[AspNet.Security.OAuth*]*,[Refit*]*,[xunit.*]*</Exclude>
-    <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
     <Threshold>69</Threshold>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,6 +52,7 @@
     <CollectCoverage Condition=" '$(WEBSITE_URL)' == '' ">true</CollectCoverage>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[AspNet.Security.OAuth*]*,[Refit*]*,[xunit.*]*</Exclude>
+    <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
     <Threshold>69</Threshold>
   </PropertyGroup>
 </Project>

--- a/src/LondonTravel.Site/Swagger/ExampleFilter.cs
+++ b/src/LondonTravel.Site/Swagger/ExampleFilter.cs
@@ -88,9 +88,9 @@ internal sealed class ExampleFilter : IOperationFilter, ISchemaFilter
     /// <typeparam name="T">The type of the attribute(s) to find.</typeparam>
     /// <param name="apiDescription">The API description.</param>
     /// <returns>
-    /// An <see cref="IList{T}"/> containing any found attributes of type <typeparamref name="T"/>.
+    /// An array containing any found attributes of type <typeparamref name="T"/>.
     /// </returns>
-    private static IList<T> GetAttributes<T>(ApiDescription apiDescription)
+    private static T[] GetAttributes<T>(ApiDescription apiDescription)
         where T : Attribute
     {
         IEnumerable<T> attributes = Enumerable.Empty<T>();


### PR DESCRIPTION
- Remove ExcludeByAttribute as it is duplicating the defaults.
- Fix code analysis warning identified in #1808.
