### PR TITLE
Use IndexOf(char, int)

### DIFF
--- a/src/LondonTravel.Site/TagHelpers/InlineStyleTagHelper.cs
+++ b/src/LondonTravel.Site/TagHelpers/InlineStyleTagHelper.cs
@@ -199,7 +199,7 @@ public class InlineStyleTagHelper : LinkTagHelper
             {
                 startIndex += SourceMapPreamble.Length;
 
-                int endIndex = css.IndexOf("*", startIndex, StringComparison.OrdinalIgnoreCase);
+                int endIndex = css.IndexOf('*', startIndex);
 
                 if (endIndex > -1)
                 {


### PR DESCRIPTION
Use char overload of `IndexOf()` to fix analyzer warning flagged in #1853.
