### PR TITLE
Build before run

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -42,6 +42,7 @@ jobs:
         npm ci
         npm run build
         Pop-Location
+        dotnet build ./src/LondonTravel.Site/LondonTravel.Site.csproj --configuration Release
         Start-Process nohup 'dotnet run --project ./src/LondonTravel.Site/LondonTravel.Site.csproj --configuration Release'
         $StatusCode = 0
         $Attempts = 0


### PR DESCRIPTION
Build the site before running it so that `npm install` etc doesn't count to the startup timeout.
