### PR TITLE
Update Facebook Graph API version

### DIFF
--- a/src/LondonTravel.Site/Identity/AuthenticationBuilderExtensions.cs
+++ b/src/LondonTravel.Site/Identity/AuthenticationBuilderExtensions.cs
@@ -75,7 +75,12 @@ public static partial class AuthenticationBuilderExtensions
 
         if (IsProviderEnabled(name, options))
         {
-            builder.AddFacebook()
+            builder.AddFacebook((p) =>
+                    {
+                        p.AuthorizationEndpoint = "https://www.facebook.com/v14.0/dialog/oauth";
+                        p.TokenEndpoint = "https://graph.facebook.com/v14.0/oauth/access_token";
+                        p.UserInformationEndpoint = "https://graph.facebook.com/v14.0/me";
+                    })
                    .Configure<FacebookOptions>(name);
         }
 

--- a/tests/LondonTravel.Site.Tests/Integration/oauth-http-bundle.json
+++ b/tests/LondonTravel.Site.Tests/Integration/oauth-http-bundle.json
@@ -102,7 +102,7 @@
     },
     {
       "comment": "Token resource for Facebook login",
-      "uri": "https://graph.facebook.com/v11.0/oauth/access_token",
+      "uri": "https://graph.facebook.com/v14.0/oauth/access_token",
       "method": "POST",
       "contentFormat": "json",
       "contentJson": {
@@ -114,7 +114,7 @@
     },
     {
       "comment": "User information resource for Facebook login",
-      "uri": "https://graph.facebook.com/v11.0/me",
+      "uri": "https://graph.facebook.com/v14.0/me",
       "ignoreQuery": true,
       "contentFormat": "json",
       "contentJson": {


### PR DESCRIPTION
Update to v14 of the API from v11 as the latter goes out of support in September.
