### PR TITLE
Disable ConfigureHttpClientDefaults()

### DIFF
--- a/src/LondonTravel.Site/Extensions/HttpServiceCollectionExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/HttpServiceCollectionExtensions.cs
@@ -21,7 +21,10 @@ public static class HttpServiceCollectionExtensions
     public static IServiceCollection AddHttpClients(this IServiceCollection services)
     {
         services.AddHttpClient()
-                .ConfigureHttpClientDefaults((p) => p.ApplyDefaultConfiguration());
+                .ApplyDefaultConfiguration();
+
+        //// TODO Re-enable when fixed in .NET 8.0.2
+        ////.ConfigureHttpClientDefaults((p) => p.ApplyDefaultConfiguration());
 
         using var serviceProvider = services.BuildServiceProvider();
         var options = serviceProvider.GetRequiredService<SiteOptions>();
@@ -31,6 +34,7 @@ public static class HttpServiceCollectionExtensions
             foreach (string name in providers.Keys)
             {
                 services.AddHttpClient(name)
+                        .ApplyDefaultConfiguration()
                         .ApplyRemoteAuthenticationConfiguration();
             }
         }
@@ -38,7 +42,7 @@ public static class HttpServiceCollectionExtensions
         services.AddHttpClient<ITflService, TflService>("TfL", (provider, client) =>
         {
             client.BaseAddress = provider.GetRequiredService<TflOptions>().BaseUri;
-        });
+        }).ApplyDefaultConfiguration();
 
         return services;
     }

--- a/src/LondonTravel.Site/Extensions/HttpServiceCollectionExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/HttpServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class HttpServiceCollectionExtensions
     public static IServiceCollection AddHttpClients(this IServiceCollection services)
     {
         services.AddHttpClient()
+                .AddHttpClient(string.Empty)
                 .ApplyDefaultConfiguration();
 
         //// TODO Re-enable when fixed in .NET 8.0.2


### PR DESCRIPTION
Disable `ConfigureHttpClientDefaults()` until the issue with it is resolved in .NET 8.0.2.
