### PR TITLE
Use token option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,11 +96,10 @@ jobs:
 
     - uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
       name: Upload coverage to Codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         file: ./artifacts/coverage/coverage.cobertura.xml
         flags: ${{ matrix.os-name }}
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Publish artifacts
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0


### PR DESCRIPTION
Use the explicit token option, rather than setting an environment variable.
