### PR TITLE
Consume .NET nightly builds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,10 +2,14 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
+    <packageSource key="dotnet9">
+      <package pattern="*" />
+    </packageSource>
     <packageSource key="dotnet-eng">
       <package pattern="Microsoft.DotNet.XliffTasks" />
     </packageSource>


### PR DESCRIPTION
Update to the latest nightly build of .NET 9.
