### PR TITLE
Handle host value being null

### DIFF
--- a/src/LondonTravel.Site/Extensions/IUrlHelperExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/IUrlHelperExtensions.cs
@@ -20,7 +20,7 @@ public static class IUrlHelperExtensions
     public static string AbsoluteContent(this IUrlHelper value, string contentPath)
     {
         var request = value.ActionContext.HttpContext.Request;
-        return value.ToAbsolute(request.Host.Value, contentPath);
+        return value.ToAbsolute(request.Host.Value ?? string.Empty, contentPath);
     }
 
     /// <summary>


### PR DESCRIPTION
Cherry-pick change from #2219 for change to nullable annotations coming in .NET 9.
