### PR TITLE
Avoid HTTPS redirection warning

### DIFF
--- a/src/LondonTravel.Site/Extensions/ILoggingBuilderExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/ILoggingBuilderExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using Azure.Monitor.OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 
 namespace MartinCostello.LondonTravel.Site.Extensions;
@@ -24,11 +23,6 @@ public static class ILoggingBuilderExtensions
         {
             p.IncludeFormattedMessage = true;
             p.IncludeScopes = true;
-
-            if (TelemetryExtensions.IsAzureMonitorConfigured())
-            {
-                p.AddAzureMonitorLogExporter();
-            }
 
             if (TelemetryExtensions.IsOtlpCollectorConfigured())
             {

--- a/src/LondonTravel.Site/Program.cs
+++ b/src/LondonTravel.Site/Program.cs
@@ -196,10 +196,14 @@ if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/error")
        .UseStatusCodePagesWithReExecute("/error", "?id={0}");
-}
 
-app.UseHsts()
-   .UseHttpsRedirection();
+    app.UseHsts();
+
+    if (!string.Equals(app.Configuration["ForwardedHeaders_Enabled"], bool.TrueString, StringComparison.OrdinalIgnoreCase))
+    {
+        app.UseHttpsRedirection();
+    }
+}
 
 app.UseResponseCompression();
 


### PR DESCRIPTION
When deployed with `ForwardedHeaders_Enabled=true` do not enable HTTPS redirection to avoid warnings being logged by platform-level HTTP requests (such as health checks).
