### PR TITLE
Skip manifest updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
 
     - name: Install .NET Workloads
       shell: pwsh
-      run: dotnet workload restore
+      run: dotnet workload restore --skip-manifest-update
 
     - name: Build, test and publish
       shell: pwsh

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Build .NET code
       if: matrix.language == 'csharp'
       run: |
-        dotnet workload restore
+        dotnet workload restore --skip-manifest-update
         dotnet build --configuration Release
 
     - name: Perform CodeQL Analysis


### PR DESCRIPTION
Skip updating manifests when restoring .NET workloads in CI.
