### PR TITLE
Switch to Azure Monitor exporter

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.4" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.3" />
     <PackageVersion Include="Azure.Identity" Version="1.11.3" />
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.1" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.2.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.3.0" />

--- a/src/LondonTravel.Site/Extensions/ILoggingBuilderExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/ILoggingBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Azure.Monitor.OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 
 namespace MartinCostello.LondonTravel.Site.Extensions;
@@ -19,14 +20,19 @@ public static class ILoggingBuilderExtensions
     /// </returns>
     public static ILoggingBuilder AddTelemetry(this ILoggingBuilder builder)
     {
-        return builder.AddOpenTelemetry((p) =>
+        return builder.AddOpenTelemetry((options) =>
         {
-            p.IncludeFormattedMessage = true;
-            p.IncludeScopes = true;
+            options.IncludeFormattedMessage = true;
+            options.IncludeScopes = true;
+
+            if (TelemetryExtensions.IsAzureMonitorConfigured())
+            {
+                options.AddAzureMonitorLogExporter();
+            }
 
             if (TelemetryExtensions.IsOtlpCollectorConfigured())
             {
-                p.AddOtlpExporter();
+                options.AddOtlpExporter();
             }
         });
     }

--- a/src/LondonTravel.Site/LondonTravel.Site.csproj
+++ b/src/LondonTravel.Site/LondonTravel.Site.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" />


### PR DESCRIPTION
Switch to Azure.Monitor.OpenTelemetry.Exporter from Azure.Monitor.OpenTelemetry.AspNetCore as the latter is not AoT friendly.
