### PR TITLE
Add explicit package reference

### DIFF
--- a/src/LondonTravel.Site.AppHost/LondonTravel.Site.AppHost.csproj
+++ b/src/LondonTravel.Site.AppHost/LondonTravel.Site.AppHost.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" />
     <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LondonTravel.Site\LondonTravel.Site.csproj" />


### PR DESCRIPTION
Add an explicit package reference for System.Text.Json so it gets updated by dotnet-outdated in pre-release testing.
