### PR TITLE
Skip workload manifest update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
 
     - name: Install .NET Workloads
       shell: pwsh
-      run: dotnet workload restore
+      run: dotnet workload restore --skip-manifest-update
 
     - name: Build, test and publish
       id: build


### PR DESCRIPTION
Skip updating .NET workload manifests to speed up CI on Windows.

<!--

Summarise the changes this Pull Request makes.

Please include a reference to a GitHub issue if appropriate.

-->
