### PR TITLE
Guard against null

### DIFF
--- a/src/LondonTravel.Site/Identity/AuthenticationBuilderExtensions.cs
+++ b/src/LondonTravel.Site/Identity/AuthenticationBuilderExtensions.cs
@@ -235,7 +235,7 @@ public static partial class AuthenticationBuilderExtensions
                         context.Scheme.Name,
                         options.StateDataFormat,
                         context.HttpContext.RequestServices.GetRequiredService<ILogger<T>>(),
-                        (p) => p.Items);
+                        (p) => p?.Items);
                 };
 
                 options.Events.OnTicketReceived = (context) =>


### PR DESCRIPTION
Handle `AuthenticationProperties` possibly being null.
