### PR TITLE
Add API snapshot test

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,15 @@ trim_trailing_whitespace = true
 [*.{config,csproj,graphviz,json,props,ruleset,targets,yml}]
 indent_size = 2
 
+[*.{received,verified}.{txt,xml,json}]
+charset = utf-8-bom
+end_of_line = lf
+indent_size = unset
+indent_style = unset
+insert_final_newline = false
+tab_width = unset
+trim_trailing_whitespace = false
+
 [*.{cs,ts}]
 file_header_template = Copyright (c) Martin Costello, 2017. All rights reserved.\nLicensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 *.sh eol=lf
+*.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.txt text eol=lf working-tree-encoding=UTF-8
+*.verified.xml text eol=lf working-tree-encoding=UTF-8

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,7 @@ updates:
         - Polly*
     xunit:
       patterns:
+        - Verify.Xunit
         - xunit*
   schedule:
     interval: daily

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ PublishProfiles
 *.[Pp]ublish.xml
 *.publishproj
 *.pubxml
+*.received.*
 *.sdf
 *.sln.cache
 *.sln.docstates

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,6 +53,7 @@
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="Verify.Xunit" Version="26.0.1" />
     <PackageVersion Include="xRetry" Version="1.9.0" />
     <PackageVersion Include="xunit" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/tests/LondonTravel.Site.Tests/Integration/ApiTests.Schema_Is_Correct.verified.txt
+++ b/tests/LondonTravel.Site.Tests/Integration/ApiTests.Schema_Is_Correct.verified.txt
@@ -1,0 +1,171 @@
+﻿{
+  openapi: 3.0.0,
+  info: {
+    title: London Travel,
+    description: London Travel is an Amazon Alexa skill for checking the status for travel in London.,
+    termsOfService: https://londontravel.martincostello.com/terms-of-service/,
+    contact: {
+      name: Martin Costello,
+      url: https://github.com/martincostello/alexa-london-travel-site
+    },
+    license: {
+      name: Apache 2.0,
+      url: https://www.apache.org/licenses/LICENSE-2.0.html
+    },
+    version: 
+  },
+  servers: [
+    {
+      url: https://localhost
+    }
+  ],
+  paths: {
+    /api/preferences: {
+      get: {
+        tags: [
+          LondonTravel.Site
+        ],
+        summary: Gets a user's preferences.,
+        description: Gets the preferences for a user associated with an access token.,
+        operationId: GetApiPreferences,
+        parameters: [
+          {
+            name: Authorization,
+            in: header,
+            description: The authorization header.,
+            schema: {
+              type: string,
+              nullable: true
+            }
+          }
+        ],
+        responses: {
+          200: {
+            description: The preferences associated with the provided access token.,
+            content: {
+              application/json: {
+                schema: {
+                  $ref: #/components/schemas/PreferencesResponse
+                },
+                example: {
+                  favoriteLines: [
+                    northern,
+                    victoria
+                  ],
+                  userId: Guid_1
+                }
+              }
+            }
+          },
+          401: {
+            description: A valid access token was not provided.,
+            content: {
+              application/json: {
+                schema: {
+                  $ref: #/components/schemas/ErrorResponse
+                },
+                example: {
+                  statusCode: 401,
+                  message: Unauthorized.,
+                  requestId: 0HKT0TM6UJASI,
+                  details: [
+                    Only the Bearer authorization scheme is supported.
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {
+      PreferencesResponse: {
+        type: object,
+        description: Represents the API response for a user's preferences.,
+        example: {
+          favoriteLines: [
+            northern,
+            victoria
+          ],
+          userId: Guid_1
+        },
+        additionalProperties: false,
+        required: [
+          favoriteLines,
+          userId
+        ],
+        properties: {
+          favoriteLines: {
+            type: array,
+            description: The Ids of the user's favorite lines, if any.,
+            items: {
+              type: string
+            }
+          },
+          userId: {
+            type: string,
+            description: The user's Id.,
+            minLength: 1
+          }
+        }
+      },
+      ErrorResponse: {
+        type: object,
+        description: Represents an error from an API resource.,
+        example: {
+          statusCode: 401,
+          message: Unauthorized.,
+          requestId: 0HKT0TM6UJASI,
+          details: [
+            Only the Bearer authorization scheme is supported.
+          ]
+        },
+        additionalProperties: false,
+        required: [
+          statusCode,
+          message,
+          requestId,
+          details
+        ],
+        properties: {
+          statusCode: {
+            type: integer,
+            description: The HTTP status code.,
+            format: int32
+          },
+          message: {
+            type: string,
+            description: The error message.,
+            minLength: 1
+          },
+          requestId: {
+            type: string,
+            description: The request Id.,
+            minLength: 1
+          },
+          details: {
+            type: array,
+            description: The error details, if any.,
+            items: {
+              type: string
+            }
+          }
+        }
+      }
+    },
+    securitySchemes: {
+      Bearer: {
+        type: http,
+        description: Access token authentication using a bearer token.,
+        in: header,
+        scheme: bearer,
+        bearerFormat: Opaque token
+      }
+    }
+  },
+  security: [
+    {}
+  ]
+}

--- a/tests/LondonTravel.Site.Tests/Integration/ApiTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/ApiTests.cs
@@ -3,8 +3,6 @@
 
 using System.Net;
 using System.Net.Http.Headers;
-using System.Net.Http.Json;
-using System.Text.Json;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Readers;
 using Microsoft.OpenApi.Validations;
@@ -128,24 +126,6 @@ public class ApiTests(TestServerFixture fixture, ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task OpenApi_Documentation_Only_Exposes_Expected_Operations()
-    {
-        // Arrange
-        using var client = Fixture.CreateClient();
-
-        // Act
-        using var actual = await client.GetFromJsonAsync<JsonDocument>("/openapi/api.json");
-
-        // Assert
-        actual.ShouldNotBeNull();
-        actual.RootElement.GetString("openapi").ShouldBe("3.0.0");
-        actual.RootElement.GetProperty("info").ValueKind.ShouldBe(JsonValueKind.Object);
-        actual.RootElement.GetProperty("components").GetProperty("schemas").EnumerateObject().Count().ShouldBe(2);
-        actual.RootElement.GetProperty("paths").EnumerateObject().Count().ShouldBe(1);
-        actual.RootElement.GetProperty("security").GetArrayLength().ShouldBe(1);
-    }
-
-    [Fact]
     public async Task Schema_Has_No_Validation_Warnings()
     {
         // Arrange
@@ -167,5 +147,18 @@ public class ApiTests(TestServerFixture fixture, ITestOutputHelper outputHelper)
 
         var errors = actual.OpenApiDocument.Validate(ruleSet);
         errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Schema_Is_Correct()
+    {
+        // Arrange
+        using var client = Fixture.CreateClient();
+
+        // Act
+        string actual = await client.GetStringAsync("/openapi/api.json");
+
+        // Assert
+        await VerifyJson(actual);
     }
 }

--- a/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
+++ b/tests/LondonTravel.Site.Tests/LondonTravel.Site.Tests.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="ReportGenerator" />
     <PackageReference Include="Shouldly" />
+    <PackageReference Include="Verify.Xunit" />
     <PackageReference Include="xRetry" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/LondonTravel.Site.Tests/xunit.runner.json
+++ b/tests/LondonTravel.Site.Tests/xunit.runner.json
@@ -1,6 +1,3 @@
 {
-  "maxParallelThreads": 1,
-  "methodDisplay": "method",
-  "methodDisplayOptions": "replaceUnderscoreWithSpace",
-  "parallelizeTestCollections": false
+  "methodDisplay": "method"
 }


### PR DESCRIPTION
- Add a snapshot API for the OpenAPI document.
- Allow tests to run in parallel again.
- Use default xunit test naming.
