### PR TITLE
Persist CosmosDB emulator data

### DIFF
--- a/src/LondonTravel.Site.AppHost/Program.cs
+++ b/src/LondonTravel.Site.AppHost/Program.cs
@@ -13,7 +13,13 @@ var blobs = builder.AddAzureStorage(Storage)
                    .AddBlobs(BlobStorage);
 
 var cosmos = builder.AddAzureCosmosDB(Cosmos)
-                    .RunAsEmulator()
+                    .RunAsEmulator((container) =>
+                    {
+                        // TODO Update persistence configuration when https://github.com/dotnet/aspire/issues/3295 released
+                        container.WithEnvironment("AZURE_COSMOS_EMULATOR_PARTITION_COUNT", "1")
+                                 .WithEnvironment("AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE", "true")
+                                 .WithVolume("londontravel-cosmosdb", "/tmp/cosmos/appdata");
+                    })
                     .AddDatabase("LondonTravel");
 
 var secrets = builder.ExecutionContext.IsPublishMode


### PR DESCRIPTION
- Persist Azure CosmosDB emulator data.
- Improve start-up time by using fewer partitions.
