### PR TITLE
Bump elliptic

### DIFF
--- a/src/LondonTravel.Site/package-lock.json
+++ b/src/LondonTravel.Site/package-lock.json
@@ -4264,9 +4264,9 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.6",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.6.tgz",
-      "integrity": "sha512-mpzdtpeCLuS3BmE3pO3Cpp5bbjlOPY2Q0PgoF+Od1XZrHLYI28Xe3ossCmYCQt11FQKEYd9+PF8jymTvtWJSHQ==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "dev": true,
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
Bump elliptic to 6.5.7 to resolve vulnerability alert.
