### PR TITLE
Bump Microsoft.DotNet.XliffTasks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="8.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.42.0" />
-    <PackageVersion Include="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.21452.1" />
+    <PackageVersion Include="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23475.1" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.8.0" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />


### PR DESCRIPTION
Bump to the latest 1.0.0 release of Microsoft.DotNet.XliffTasks.
