### PR TITLE
Use System.Text.Json for CosmosDB

### DIFF
--- a/src/LondonTravel.Site.AppHost/Program.cs
+++ b/src/LondonTravel.Site.AppHost/Program.cs
@@ -9,7 +9,7 @@ const string KeyVault = "AzureKeyVault";
 const string Storage = "AzureStorage";
 
 var blobs = builder.AddAzureStorage(Storage)
-                   .RunAsEmulator((p) => p.WithImageTag("3.31.0")) // TODO Remove tag when https://github.com/dotnet/aspire/issues/5078 released
+                   .RunAsEmulator()
                    .AddBlobs(BlobStorage);
 
 var cosmos = builder.AddAzureCosmosDB(Cosmos)

--- a/src/LondonTravel.Site/Program.cs
+++ b/src/LondonTravel.Site/Program.cs
@@ -45,6 +45,7 @@ if (builder.Configuration["ConnectionStrings:AzureCosmos"] is { Length: > 0 })
         {
             options.ApplicationName = "london-travel";
             options.RequestTimeout = TimeSpan.FromSeconds(15);
+            options.UseSystemTextJsonSerializerWithOptions = System.Text.Json.JsonSerializerOptions.Default;
 
             if (builder.Configuration["Site:Authentication:UserStore:CurrentLocation"] is { Length: > 0 } region)
             {


### PR DESCRIPTION
- Consume change from #2750 to use System.Text.Json with the CosmosDB client.
- Remove fixed tag for storage emulator as should not be needed since #2735.