### PR TITLE
Update NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,20 +4,20 @@
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Azure.Security.KeyVault" Version="8.2.0" />
-    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="8.2.0" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.2.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure.CosmosDB" Version="8.2.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="8.2.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="8.2.0" />
-    <PackageVersion Include="Aspire.Microsoft.Azure.Cosmos" Version="8.2.0" />
-    <PackageVersion Include="AspNet.Security.OAuth.Amazon" Version="9.0.0-rc.1.24460.76" />
-    <PackageVersion Include="AspNet.Security.OAuth.Apple" Version="9.0.0-rc.1.24460.76" />
-    <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="9.0.0-rc.1.24460.76" />
+    <PackageVersion Include="Aspire.Azure.Security.KeyVault" Version="8.2.1" />
+    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="8.2.1" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.2.1" />
+    <PackageVersion Include="Aspire.Hosting.Azure.CosmosDB" Version="8.2.1" />
+    <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="8.2.1" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="8.2.1" />
+    <PackageVersion Include="Aspire.Microsoft.Azure.Cosmos" Version="8.2.1" />
+    <PackageVersion Include="AspNet.Security.OAuth.Amazon" Version="9.0.0-rc.1.24464.64" />
+    <PackageVersion Include="AspNet.Security.OAuth.Apple" Version="9.0.0-rc.1.24464.64" />
+    <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="9.0.0-rc.1.24464.64" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.4" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.4" />
-    <PackageVersion Include="Azure.Identity" Version="1.12.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.12.1" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
@@ -30,14 +30,14 @@
     <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="9.0.0-rc.1.24452.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rc.1.24452.1" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rc.1.24452.1" />
-    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.43.0" />
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.43.1" />
     <PackageVersion Include="Microsoft.DotNet.XliffTasks" Version="9.0.0-beta.24414.3" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0-preview.8.24460.1" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.1.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.21" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.21" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.46.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.47.0" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.6.2" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
@@ -45,18 +45,18 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Resources.Azure" Version="1.0.0-beta.8" />
+    <PackageVersion Include="OpenTelemetry.Resources.Azure" Version="1.0.0-beta.9" />
     <PackageVersion Include="OpenTelemetry.Resources.Container" Version="1.0.0-beta.9" />
-    <PackageVersion Include="Polly.Extensions" Version="8.4.1" />
-    <PackageVersion Include="Polly.RateLimiting" Version="8.4.1" />
+    <PackageVersion Include="Polly.Extensions" Version="8.4.2" />
+    <PackageVersion Include="Polly.RateLimiting" Version="8.4.2" />
     <PackageVersion Include="ReportGenerator" Version="5.3.9" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0-rc.1.24431.7" />
-    <PackageVersion Include="Verify.Xunit" Version="26.4.4" />
+    <PackageVersion Include="Verify.Xunit" Version="26.6.0" />
     <PackageVersion Include="xRetry" Version="1.9.0" />
-    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>


### PR DESCRIPTION
Update NuGet packages to their latest versions while dependabot does not support .NET 9.
