### PR TITLE
Remove report-uri

### DIFF
--- a/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/LondonTravel.Site/Middleware/CustomHttpHeadersMiddleware.cs
@@ -88,7 +88,6 @@ public sealed class CustomHttpHeadersMiddleware(
                     context.Response.Headers.Append("Expect-CT", _expectCTValue);
                 }
 
-                context.Response.Headers.Append("Report-To", /*lang=json,strict*/@"{""group"":""default"",""max_age"":31536000,""endpoints"":[{""url"":""https://martincostello.report-uri.com/a/d/g""}],""include_subdomains"":false}");
                 context.Response.Headers.Append("NEL", /*lang=json,strict*/@"{""report_to"":""default"",""max_age"":31536000,""include_subdomains"":false}");
 
 #if DEBUG
@@ -139,21 +138,15 @@ public sealed class CustomHttpHeadersMiddleware(
             "max-age={0};",
             (int)(options?.CertificateTransparency?.MaxAge.TotalSeconds ?? default));
 
-        if (enforce)
+        if (enforce && options?.ExternalLinks?.Reports?.ExpectCTEnforce is { } enforceUri)
         {
-            if (options?.ExternalLinks?.Reports?.ExpectCTEnforce != null)
-            {
-                builder.Append(" report-uri ");
-                builder.Append(options.ExternalLinks.Reports.ExpectCTEnforce);
-            }
+            builder.Append(" report-uri ");
+            builder.Append(enforceUri);
         }
-        else
+        else if (options?.ExternalLinks?.Reports?.ExpectCTReportOnly is { } reportUri)
         {
-            if (options?.ExternalLinks?.Reports?.ExpectCTReportOnly != null)
-            {
-                builder.Append(" report-uri ");
-                builder.Append(options.ExternalLinks.Reports.ExpectCTReportOnly);
-            }
+            builder.Append(" report-uri ");
+            builder.Append(reportUri);
         }
 
         return builder.ToString();
@@ -301,9 +294,9 @@ public sealed class CustomHttpHeadersMiddleware(
             builder.Append("upgrade-insecure-requests;");
         }
 
-        if (options?.ExternalLinks?.Reports?.ContentSecurityPolicy != null)
+        if (options?.ExternalLinks?.Reports?.ContentSecurityPolicy is { } reportUri)
         {
-            builder.Append(CultureInfo.InvariantCulture, $"report-uri {options.ExternalLinks.Reports.ContentSecurityPolicy};");
+            builder.Append(CultureInfo.InvariantCulture, $"report-uri {reportUri};");
         }
 
         return builder.ToString();

--- a/src/LondonTravel.Site/Pages/Technology/Index.cshtml
+++ b/src/LondonTravel.Site/Pages/Technology/Index.cshtml
@@ -108,7 +108,6 @@
                 <li>NuGet</li>
                 <li>OpenTelemetry</li>
                 <li>Polly</li>
-                <li>report-uri.io</li>
                 <li>Shouldly</li>
                 <li>StyleCop Analyzers</li>
                 <li>TfL API</li>

--- a/src/LondonTravel.Site/appsettings.json
+++ b/src/LondonTravel.Site/appsettings.json
@@ -148,11 +148,11 @@
       "Cdn": "https://cdn.martincostello.com/",
       "Skill": "https://www.amazon.co.uk/dp/B01NB0T86R",
       "Reports": {
-        "ContentSecurityPolicy": "https://martincostello.report-uri.com/r/d/csp/enforce",
-        "ContentSecurityPolicyReportOnly": "https://martincostello.report-uri.com/r/d/csp/reportOnly",
-        "ExpectCTEnforce": "https://martincostello.report-uri.com/r/d/ct/enforce",
-        "ExpectCTReportOnly": "https://martincostello.report-uri.com/r/d/ct/reportOnly",
-        "ExpectStaple": "https://martincostello.report-uri.com/r/d/staple/reportOnly"
+        "ContentSecurityPolicy": "",
+        "ContentSecurityPolicyReportOnly": "",
+        "ExpectCTEnforce": "",
+        "ExpectCTReportOnly": "",
+        "ExpectStaple": ""
       }
     },
     "Metadata": {

--- a/tests/LondonTravel.Site.Tests/EndToEnd/ResourceTests.cs
+++ b/tests/LondonTravel.Site.Tests/EndToEnd/ResourceTests.cs
@@ -69,7 +69,6 @@ public class ResourceTests(WebsiteFixture fixture)
             "NEL",
             "Permissions-Policy",
             "Referrer-Policy",
-            "Report-To",
             "X-Content-Type-Options",
             "X-CSP-Nonce",
             "X-Download-Options",

--- a/tests/LondonTravel.Site.Tests/Integration/ResourceTests.cs
+++ b/tests/LondonTravel.Site.Tests/Integration/ResourceTests.cs
@@ -127,7 +127,6 @@ public class ResourceTests(TestServerFixture fixture, ITestOutputHelper outputHe
             "NEL",
             "Permissions-Policy",
             "Referrer-Policy",
-            "Report-To",
             "X-Content-Type-Options",
             "X-CSP-Nonce",
             "X-Download-Options",
@@ -151,7 +150,6 @@ public class ResourceTests(TestServerFixture fixture, ITestOutputHelper outputHe
 
     [Theory]
     [InlineData("NEL")]
-    [InlineData("Report-To")]
     public async Task Response_Headers_Is_Valid_Json(string name)
     {
         // Act


### PR DESCRIPTION
Remove usage of report-uri.io as the free tier is being shutdown in ~90 days.
