### PR TITLE
Set resource builder

### DIFF
--- a/src/LondonTravel.Site.AppHost/Program.cs
+++ b/src/LondonTravel.Site.AppHost/Program.cs
@@ -19,7 +19,7 @@ var cosmos = builder.AddAzureCosmosDB(Cosmos)
                                  .WithLifetime(ContainerLifetime.Persistent)
                                  .WithPartitionCount(1);
                     })
-                    .AddDatabase("LondonTravel");
+                    .AddCosmosDatabase("LondonTravel");
 
 var secrets = builder.ExecutionContext.IsPublishMode
     ? builder.AddAzureKeyVault(KeyVault)

--- a/src/LondonTravel.Site/Extensions/ILoggingBuilderExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/ILoggingBuilderExtensions.cs
@@ -25,6 +25,8 @@ public static class ILoggingBuilderExtensions
             options.IncludeFormattedMessage = true;
             options.IncludeScopes = true;
 
+            options.SetResourceBuilder(TelemetryExtensions.ResourceBuilder);
+
             if (TelemetryExtensions.IsAzureMonitorConfigured())
             {
                 options.AddAzureMonitorLogExporter();

--- a/src/LondonTravel.Site/Extensions/TelemetryExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/TelemetryExtensions.cs
@@ -25,14 +25,14 @@ public static class TelemetryExtensions
         ["api.github.com"] = "GitHub",
     };
 
+    public static ResourceBuilder ResourceBuilder { get; } = ResourceBuilder.CreateDefault()
+        .AddService(ApplicationTelemetry.ServiceName, serviceVersion: ApplicationTelemetry.ServiceVersion)
+        .AddAzureAppServiceDetector()
+        .AddContainerDetector();
+
     public static void AddTelemetry(this IServiceCollection services, IWebHostEnvironment environment)
     {
         ArgumentNullException.ThrowIfNull(services);
-
-        var resourceBuilder = ResourceBuilder.CreateDefault()
-            .AddService(ApplicationTelemetry.ServiceName, serviceVersion: ApplicationTelemetry.ServiceVersion)
-            .AddAzureAppServiceDetector()
-            .AddContainerDetector();
 
         if (IsAzureMonitorConfigured())
         {
@@ -44,7 +44,7 @@ public static class TelemetryExtensions
             .AddOpenTelemetry()
             .WithMetrics((builder) =>
             {
-                builder.SetResourceBuilder(resourceBuilder)
+                builder.SetResourceBuilder(ResourceBuilder)
                        .AddAspNetCoreInstrumentation()
                        .AddHttpClientInstrumentation()
                        .AddRuntimeInstrumentation();
@@ -64,7 +64,7 @@ public static class TelemetryExtensions
                 // See https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md
                 AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", true);
 
-                builder.SetResourceBuilder(resourceBuilder)
+                builder.SetResourceBuilder(ResourceBuilder)
                        .AddAspNetCoreInstrumentation()
                        .AddHttpClientInstrumentation()
                        .AddSource(ApplicationTelemetry.ServiceName)


### PR DESCRIPTION
- Associate the resource builder with the OTel logging collector too.
- Use `AddCosmosDatabase()` instead of `AddDatabase()`.
