### PR TITLE
Fix missing telemetry

### DIFF
--- a/src/LondonTravel.Site/Extensions/TelemetryExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/TelemetryExtensions.cs
@@ -102,10 +102,10 @@ public static class TelemetryExtensions
     }
 
     internal static bool IsOtlpCollectorConfigured()
-        => !string.IsNullOrEmpty(AzureMonitorConnectionString());
+        => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT"));
 
     internal static bool IsAzureMonitorConfigured()
-        => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING"));
+        => !string.IsNullOrEmpty(AzureMonitorConnectionString());
 
     private static string? AzureMonitorConnectionString()
         => Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");


### PR DESCRIPTION
Fix OpenTelemetry not being enabled due to looking for the Azure Monitor connection string instead of the OpenTelemetry exporter OLTP endpoint.
