### PR TITLE
Fix incorrectly cached calls

### DIFF
--- a/src/LondonTravel.Site/Services/Data/DocumentCollectionInitializer.cs
+++ b/src/LondonTravel.Site/Services/Data/DocumentCollectionInitializer.cs
@@ -108,6 +108,8 @@ public sealed partial class DocumentCollectionInitializer(
             Log.CreatedCollection(logger, id, _databaseName);
         }
 
+        _existingContainers.AddOrUpdate(id, true, static (_, _) => true);
+
         return created;
     }
 


### PR DESCRIPTION
Fix `_existingContainers` never being populated, so the databases and containers were always being fetched.
