### PR TITLE
Avoid Uri allocations

### DIFF
--- a/src/LondonTravel.Site/Extensions/HttpRequestExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/HttpRequestExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using MartinCostello.LondonTravel.Site.Options;
+
 namespace MartinCostello.LondonTravel.Site.Extensions;
 
 /// <summary>
@@ -45,5 +47,60 @@ public static class HttpRequestExtensions
         }
 
         return canonicalUri;
+    }
+
+    /// <summary>
+    /// Converts a virtual (relative) path to an CDN absolute URI, if configured.
+    /// </summary>
+    /// <param name="value">The <see cref="HttpRequest"/>.</param>
+    /// <param name="contentPath">The virtual path of the content.</param>
+    /// <param name="options">The current site configuration.</param>
+    /// <returns>The CDN absolute URI, if configured; otherwise the application absolute URI.</returns>
+    public static string CdnContent(this HttpRequest value, string contentPath, SiteOptions options)
+    {
+        var cdn = options?.ExternalLinks?.Cdn;
+
+        // Prefer empty images to a NullReferenceException
+        if (cdn == null)
+        {
+            return string.Empty;
+        }
+
+        return $"{cdn}london-travel_{value.Content(contentPath)?.TrimStart('/')}";
+    }
+
+    /// <summary>
+    /// Converts a virtual (relative) path to a relative URI.
+    /// </summary>
+    /// <param name="request">The <see cref="HttpRequest"/>.</param>
+    /// <param name="contentPath">The virtual path of the content.</param>
+    /// <param name="appendVersion">Whether to append a version to the URL.</param>
+    /// <returns>The relatve URI to the content.</returns>
+    public static string? Content(this HttpRequest request, string? contentPath, bool appendVersion = true)
+    {
+        string? result = string.Empty;
+
+        if (!string.IsNullOrEmpty(contentPath))
+        {
+            if (contentPath[0] == '~')
+            {
+                var segment = new PathString(contentPath[1..]);
+                var applicationPath = request.PathBase;
+
+                var path = applicationPath.Add(segment);
+                result = path.Value;
+            }
+            else
+            {
+                result = contentPath;
+            }
+        }
+
+        if (appendVersion)
+        {
+            result += $"?v={GitMetadata.Commit}";
+        }
+
+        return result;
     }
 }

--- a/src/LondonTravel.Site/Extensions/IUrlHelperExtensions.cs
+++ b/src/LondonTravel.Site/Extensions/IUrlHelperExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using MartinCostello.LondonTravel.Site.Options;
 using Microsoft.AspNetCore.Mvc;
 
 namespace MartinCostello.LondonTravel.Site.Extensions;
@@ -21,38 +20,6 @@ public static class IUrlHelperExtensions
     {
         var request = value.ActionContext.HttpContext.Request;
         return value.ToAbsolute(request.Host.Value ?? string.Empty, contentPath);
-    }
-
-    /// <summary>
-    /// Converts a virtual (relative) path to an CDN absolute URI, if configured.
-    /// </summary>
-    /// <param name="value">The <see cref="IUrlHelper"/>.</param>
-    /// <param name="contentPath">The virtual path of the content.</param>
-    /// <param name="options">The current site configuration.</param>
-    /// <param name="appendVersion">Whether to append a version query string parameter to the URL.</param>
-    /// <returns>The CDN absolute URI, if configured; otherwise the application absolute URI..</returns>
-    public static string CdnContent(this IUrlHelper value, string contentPath, SiteOptions? options, bool appendVersion = true)
-    {
-        var cdn = options?.ExternalLinks?.Cdn;
-
-        // Prefer empty images to a NullReferenceException
-        if (cdn == null)
-        {
-            return string.Empty;
-        }
-
-        // Azure Blob storage is case-sensitive, so force all URLs to lowercase
-#pragma warning disable CA1308
-        string url = value.ToAbsolute(cdn.Host, $"london-travel_{contentPath.ToLowerInvariant().TrimStart('/')}");
-#pragma warning restore CA1308
-
-        // asp-append-version="true" does not work for non-local resources
-        if (appendVersion)
-        {
-            url += $"?v={GitMetadata.Commit}";
-        }
-
-        return url;
     }
 
     /// <summary>

--- a/src/LondonTravel.Site/Pages/Shared/_Links.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_Links.cshtml
@@ -1,32 +1,29 @@
 @model Tuple<string, SiteOptions>
 @{
-    string canonical = Model!.Item1;
+    var canonical = Model!.Item1;
     SiteOptions options = Model.Item2;
+    var request = Context.Request;
 }
-    <link rel="dns-prefetch" href="https://@options?.ExternalLinks?.Cdn?.Host">
-    <link rel="dns-prefetch" href="https://az416426.vo.msecnd.net">
-    <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
-    <link rel="dns-prefetch" href="https://dc.services.visualstudio.com">
-    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
-    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
-    <link rel="dns-prefetch" href="https://www.googletagmanager.com">
-    <link rel="dns-prefetch" href="https://www.gravatar.com">
-    <link rel="preconnect" href="https://@options?.ExternalLinks?.Cdn?.Host">
-    <link rel="preconnect" href="https://az416426.vo.msecnd.net">
-    <link rel="preconnect" href="https://cdnjs.cloudflare.com">
-    <link rel="preconnect" href="https://dc.services.visualstudio.com">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link rel="preconnect" href="https://www.googletagmanager.com">
-    <link rel="preconnect" href="https://www.gravatar.com">
-    <link rel="canonical" href="@canonical">
-    <link rel="manifest" href="@Url.Content("~/manifest.webmanifest")">
-    <link rel="sitemap" type="application/xml" href="@Url.Content("~/sitemap.xml")" asp-append-version="true">
-    <link rel="shortcut icon" href="@Url.CdnContent("favicon.ico", options)">
-    <link rel="shortcut icon" sizes="16x16" href="@Url.CdnContent("favicon-16x16.png", options)">
-    <link rel="shortcut icon" sizes="32x32" href="@Url.CdnContent("favicon-32x32.png", options)">
-    <link rel="shortcut icon" sizes="96x96" href="@Url.CdnContent("favicon-96x96.png", options)">
-    <link rel="shortcut icon" sizes="152x152" href="@Url.CdnContent("favicon-152x152.png", options)">
-    <link rel="shortcut icon" sizes="192x192" href="@Url.CdnContent("favicon-192x192.png", options)">
-    <link rel="shortcut icon" sizes="196x196" href="@Url.CdnContent("favicon-196x196.png", options)">
-    <link rel="apple-touch-icon" href="@Url.CdnContent("apple-touch-icon-180x180.png", options)">
+<link rel="dns-prefetch" href="https://@(options.ExternalLinks?.Cdn?.Host)">
+<link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
+<link rel="dns-prefetch" href="https://fonts.googleapis.com">
+<link rel="dns-prefetch" href="https://fonts.gstatic.com">
+<link rel="dns-prefetch" href="https://www.googletagmanager.com">
+<link rel="dns-prefetch" href="https://www.gravatar.com">
+<link rel="preconnect" href="https://@(options.ExternalLinks?.Cdn?.Host)">
+<link rel="preconnect" href="https://cdnjs.cloudflare.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com">
+<link rel="preconnect" href="https://www.googletagmanager.com">
+<link rel="preconnect" href="https://www.gravatar.com">
+<link rel="canonical" href="@canonical">
+<link rel="manifest" href="@Url.Content("~/manifest.webmanifest")">
+<link rel="sitemap" type="application/xml" href="@Url.Content("~/sitemap.xml")" asp-append-version="true">
+<link rel="shortcut icon" href="@request.CdnContent("favicon.ico", options)">
+<link rel="shortcut icon" sizes="16x16" href="@request.CdnContent("favicon-16x16.png", options)">
+<link rel="shortcut icon" sizes="32x32" href="@request.CdnContent("favicon-32x32.png", options)">
+<link rel="shortcut icon" sizes="96x96" href="@request.CdnContent("favicon-96x96.png", options)">
+<link rel="shortcut icon" sizes="152x152" href="@request.CdnContent("favicon-152x152.png", options)">
+<link rel="shortcut icon" sizes="192x192" href="@request.CdnContent("favicon-192x192.png", options)">
+<link rel="shortcut icon" sizes="196x196" href="@request.CdnContent("favicon-196x196.png", options)">
+<link rel="apple-touch-icon" href="@request.CdnContent("apple-touch-icon-180x180.png", options)">

--- a/src/LondonTravel.Site/Pages/Shared/_Meta.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_Meta.cshtml
@@ -4,113 +4,114 @@
 @inject IWebHostEnvironment Hosting
 @{
     bool renderAnalytics = string.Equals(Config.AzureEnvironment(), "production", StringComparison.OrdinalIgnoreCase);
+    var request = Context.Request;
 }
-    <meta charset="utf-8" />
-    <title>@Model!.Title</title>
-    <meta name="author" content="@Model.Author" />
-    <meta name="bitcoin" content="@Model.Bitcoin" />
-    <meta name="copyright" content="@SR.CopyrightText" />
-    <meta name="description" content="@Model.Description" />
-    <meta name="language" content="en" />
-    <meta name="keywords" content="@Model.Keywords" />
-    <meta name="referrer" content="no-referrer-when-downgrade" />
-    <meta name="robots" content="@Model.Robots" />
-    <meta name="theme-color" content="#ffffff" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta property="fb:app_id" content="@Model.FacebookApp" />
-    <meta property="fb:profile_id" content="@Model.FacebookProfile" />
-    <meta property="og:description" content="@Model.Description" />
-    @if (!string.IsNullOrEmpty(Model.ImageUri))
-    {
+<meta charset="utf-8" />
+<title>@Model!.Title</title>
+<meta name="author" content="@Model.Author" />
+<meta name="bitcoin" content="@Model.Bitcoin" />
+<meta name="copyright" content="@SR.CopyrightText" />
+<meta name="description" content="@Model.Description" />
+<meta name="language" content="en" />
+<meta name="keywords" content="@Model.Keywords" />
+<meta name="referrer" content="no-referrer-when-downgrade" />
+<meta name="robots" content="@Model.Robots" />
+<meta name="theme-color" content="#ffffff" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta property="fb:app_id" content="@Model.FacebookApp" />
+<meta property="fb:profile_id" content="@Model.FacebookProfile" />
+<meta property="og:description" content="@Model.Description" />
+@if (!string.IsNullOrEmpty(Model.ImageUri))
+{
     <meta property="og:image" content="@Model.ImageUri" />
     <meta name="twitter:image" content="@Model.ImageUri" />
     <meta name="twitter:image:alt" content="@Model.ImageAltText" />
-    }
-    else
-    {
-    <meta property="og:image" content="@Url.CdnContent("london-travel-216x216.png", Options)" />
-    <meta property="og:image:secure_url" content="@Url.CdnContent("london-travel-216x216.png", Options)" />
+}
+else
+{
+    <meta property="og:image" content="@request.CdnContent("london-travel-216x216.png", Options)" />
+    <meta property="og:image:secure_url" content="@request.CdnContent("london-travel-216x216.png", Options)" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="216" />
     <meta property="og:image:height" content="216" />
-    <meta name="twitter:image" content="@Url.CdnContent("london-travel-108x108.png", Options)" />
+    <meta name="twitter:image" content="@request.CdnContent("london-travel-108x108.png", Options)" />
     <meta name="twitter:image:alt" content="@Model.SiteName" />
-    }
-    <meta property="og:locale" content="en_GB" />
-    <meta property="og:site_name" content="@Model.SiteName" />
-    <meta property="og:title" content="@Model.Title" />
-    <meta property="og:type" content="@Model.SiteType" />
-    <meta property="og:url" content="@Model.CanonicalUri" />
-    <meta name="twitter:card" content="@Model.TwitterCard" />
-    <meta name="twitter:creator" content="@Model.TwitterHandle" />
-    <meta name="twitter:description" content="@Model.Description" />
-    <meta name="twitter:domain" content="@Model.HostName" />
-    <meta name="twitter:site" content="@Model.TwitterHandle" />
-    <meta name="twitter:title" content="@Model.Title" />
-    <meta name="twitter:url" content="@Model.CanonicalUri" />
-    <meta name="application-name" content="@Model.SiteName" />
-    <meta name="google-analytics" content="@(renderAnalytics ? Options.Analytics?.Google : string.Empty)" />
-    <meta name="google-site-verification" content="ji6SNsPQEbNQmF252sQgQFswh-b6cDnNOa3AHvgo4J0" />
-    <meta name="msapplication-config" content="@Url.Content("~/browserconfig.xml")" />
-    <meta name="msapplication-navbutton-color" content="#2b5797" />
-    <meta name="msapplication-starturl" content="/" />
-    <meta name="msapplication-TileColor" content="#2b5797" />
-    <meta name="msapplication-TileImage" content="@Url.CdnContent("mstile-144x144.png", Options)" />
-    <meta name="x-request-locale" content="@CultureInfo.CurrentUICulture.Name" />
-    <meta name="x-site-branch" content="@GitMetadata.Branch" />
-    <meta name="x-site-revision" content="@GitMetadata.Commit" />
-    @if (User?.Identity?.IsAuthenticated == true)
-    {
+}
+<meta property="og:locale" content="en_GB" />
+<meta property="og:site_name" content="@Model.SiteName" />
+<meta property="og:title" content="@Model.Title" />
+<meta property="og:type" content="@Model.SiteType" />
+<meta property="og:url" content="@Model.CanonicalUri" />
+<meta name="twitter:card" content="@Model.TwitterCard" />
+<meta name="twitter:creator" content="@Model.TwitterHandle" />
+<meta name="twitter:description" content="@Model.Description" />
+<meta name="twitter:domain" content="@Model.HostName" />
+<meta name="twitter:site" content="@Model.TwitterHandle" />
+<meta name="twitter:title" content="@Model.Title" />
+<meta name="twitter:url" content="@Model.CanonicalUri" />
+<meta name="application-name" content="@Model.SiteName" />
+<meta name="google-analytics" content="@(renderAnalytics ? Options.Analytics?.Google : string.Empty)" />
+<meta name="google-site-verification" content="ji6SNsPQEbNQmF252sQgQFswh-b6cDnNOa3AHvgo4J0" />
+<meta name="msapplication-config" content="@Url.Content("~/browserconfig.xml")" />
+<meta name="msapplication-navbutton-color" content="#2b5797" />
+<meta name="msapplication-starturl" content="/" />
+<meta name="msapplication-TileColor" content="#2b5797" />
+<meta name="msapplication-TileImage" content="@request.CdnContent("mstile-144x144.png", Options)" />
+<meta name="x-request-locale" content="@CultureInfo.CurrentUICulture.Name" />
+<meta name="x-site-branch" content="@GitMetadata.Branch" />
+<meta name="x-site-revision" content="@GitMetadata.Commit" />
+@if (User?.Identity?.IsAuthenticated == true)
+{
     <meta name="x-site-user-id" content="@User.GetUserId()" />
-    }
-    <script type="application/ld+json">
-    {
+}
+<script type="application/ld+json">
+{
+    "@@context": "http://schema.org",
+    "@@type": "WebSite",
+    "name": "@Model.SiteName",
+    "alternateName": "@Model.Description",
+    "author" : {
+        "@@type" : "Person",
+        "name" : "@Options.Metadata?.Author?.Name"
+    },
+    "description": "@Model.Description",
+    "image": "@Options.Metadata?.Image",
+    "url": "@Context.Request.Canonical("/")"
+}
+</script>
+<script type="application/ld+json">
+{
+    "@@context" : "http://schema.org",
+    "@@type" : "SoftwareApplication",
+    "name" : "@Model.SiteName",
+    "aggregateRating": {
         "@@context": "http://schema.org",
-        "@@type": "WebSite",
-        "name": "@Model.SiteName",
-        "alternateName": "@Model.Description",
-        "author" : {
-            "@@type" : "Person",
-            "name" : "@Options.Metadata?.Author?.Name"
-        },
-        "description": "@Model.Description",
-        "image": "@Options.Metadata?.Image",
-        "url": "@Context.Request.Canonical("/")"
-    }
-    </script>
-    <script type="application/ld+json">
-    {
-        "@@context" : "http://schema.org",
-        "@@type" : "SoftwareApplication",
-        "name" : "@Model.SiteName",
-        "aggregateRating": {
-            "@@context": "http://schema.org",
-            "@@type": "AggregateRating",
-            "bestRating": @Model.Reviews?.BestRating,
-            "worstRating": @Model.Reviews?.WorstRating,
-            "ratingValue": @Model.Reviews?.AverageRating,
-            "reviewCount": @Model.Reviews?.ReviewCount
-        },
-        "applicationCategory": "Travel & Transportation",
-        "applicationSubCategory": "Public Transportation",
-        "author" : {
-            "@@type" : "Person",
-            "name" : "@Options.Metadata?.Author?.Name"
-        },
-        "countriesSupported": "gb",
-        "dateCreated": "2017-02-04",
-        "description": "The London Travel Alexa skill allows you to ask Alexa for information about disruption on public transport in London.",
-        "installUrl": "@Options.ExternalLinks?.Skill",
-        "inLanguage": "en-GB",
-        "license": "https://github.com/martincostello/alexa-london-travel/blob/main/LICENSE",
-        "offers": {
-            "@@context": "http://schema.org",
-            "@@type": "Offer",
-            "price": "0.00",
-            "priceCurrency": "GBP"
-        },
-        "operatingSystem": "Amazon Echo",
-        "releaseNotes": "https://github.com/martincostello/alexa-london-travel/releases/latest",
-        "url": "https://github.com/martincostello/alexa-london-travel"
-    }
-    </script>
+        "@@type": "AggregateRating",
+        "bestRating": @Model.Reviews?.BestRating,
+        "worstRating": @Model.Reviews?.WorstRating,
+        "ratingValue": @Model.Reviews?.AverageRating,
+        "reviewCount": @Model.Reviews?.ReviewCount
+    },
+    "applicationCategory": "Travel & Transportation",
+    "applicationSubCategory": "Public Transportation",
+    "author" : {
+        "@@type" : "Person",
+        "name" : "@Options.Metadata?.Author?.Name"
+    },
+    "countriesSupported": "gb",
+    "dateCreated": "2017-02-04",
+    "description": "The London Travel Alexa skill allows you to ask Alexa for information about disruption on public transport in London.",
+    "installUrl": "@Options.ExternalLinks?.Skill",
+    "inLanguage": "en-GB",
+    "license": "https://github.com/martincostello/alexa-london-travel/blob/main/LICENSE",
+    "offers": {
+        "@@context": "http://schema.org",
+        "@@type": "Offer",
+        "price": "0.00",
+        "priceCurrency": "GBP"
+    },
+    "operatingSystem": "Amazon Echo",
+    "releaseNotes": "https://github.com/martincostello/alexa-london-travel/releases/latest",
+    "url": "https://github.com/martincostello/alexa-london-travel"
+}
+</script>

--- a/src/LondonTravel.Site/Pages/Shared/_Navbar.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_Navbar.cshtml
@@ -1,11 +1,14 @@
+@{
+    var request = Context.Request;
+}
 <nav class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
     <div class="container">
         <a asp-page="@SiteRoutes.Home" class="navbar-brand" title="@SR.HomepageLinkAltText" data-ga-label="Homepage Navbar">
             <span>
                 @SR.BrandName
-                <lazyimg src="@Url.CdnContent("avatar.png", Options)" class="pb-1" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
+                <lazyimg src="@request.CdnContent("avatar.png", Options)" class="pb-1" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
                 <noscript>
-                    <img src="@Url.CdnContent("avatar.png", Options)" class="pb-1" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
+                    <img src="@request.CdnContent("avatar.png", Options)" class="pb-1" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
                 </noscript>
             </span>
         </a>

--- a/src/LondonTravel.Site/Pages/Shared/_SignInPartial.cshtml
+++ b/src/LondonTravel.Site/Pages/Shared/_SignInPartial.cshtml
@@ -1,7 +1,7 @@
 @inject Microsoft.AspNetCore.Identity.SignInManager<LondonTravelUser> SignInManager
 @{
     string displayName = User.GetDisplayName();
-    string avatarUrl = User.GetAvatarUrl(Url.CdnContent("avatar.png", Options));
+    string avatarUrl = User.GetAvatarUrl(Context.Request.CdnContent("avatar.png", Options));
 }
 @if (SignInManager.IsSignedIn(User))
 {

--- a/src/LondonTravel.Site/Views/Shared/_Links.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Links.cshtml
@@ -2,31 +2,28 @@
 @{
     string canonical = Model!.Item1;
     SiteOptions options = Model.Item2;
+    var request = Context.Request;
 }
-    <link rel="dns-prefetch" href="https://@options?.ExternalLinks?.Cdn?.Host">
-    <link rel="dns-prefetch" href="https://az416426.vo.msecnd.net">
-    <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
-    <link rel="dns-prefetch" href="https://dc.services.visualstudio.com">
-    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
-    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
-    <link rel="dns-prefetch" href="https://www.googletagmanager.com">
-    <link rel="dns-prefetch" href="https://www.gravatar.com">
-    <link rel="preconnect" href="https://@options?.ExternalLinks?.Cdn?.Host">
-    <link rel="preconnect" href="https://az416426.vo.msecnd.net">
-    <link rel="preconnect" href="https://cdnjs.cloudflare.com">
-    <link rel="preconnect" href="https://dc.services.visualstudio.com">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link rel="preconnect" href="https://www.googletagmanager.com">
-    <link rel="preconnect" href="https://www.gravatar.com">
-    <link rel="canonical" href="@canonical">
-    <link rel="manifest" href="@Url.Content("~/manifest.webmanifest")">
-    <link rel="sitemap" type="application/xml" href="@Url.Content("~/sitemap.xml")" asp-append-version="true">
-    <link rel="shortcut icon" href="@Url.CdnContent("favicon.ico", options)">
-    <link rel="shortcut icon" sizes="16x16" href="@Url.CdnContent("favicon-16x16.png", options)">
-    <link rel="shortcut icon" sizes="32x32" href="@Url.CdnContent("favicon-32x32.png", options)">
-    <link rel="shortcut icon" sizes="96x96" href="@Url.CdnContent("favicon-96x96.png", options)">
-    <link rel="shortcut icon" sizes="152x152" href="@Url.CdnContent("favicon-152x152.png", options)">
-    <link rel="shortcut icon" sizes="192x192" href="@Url.CdnContent("favicon-192x192.png", options)">
-    <link rel="shortcut icon" sizes="196x196" href="@Url.CdnContent("favicon-196x196.png", options)">
-    <link rel="apple-touch-icon" href="@Url.CdnContent("apple-touch-icon-180x180.png", options)">
+<link rel="dns-prefetch" href="https://@(options.ExternalLinks?.Cdn?.Host)">
+<link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
+<link rel="dns-prefetch" href="https://fonts.googleapis.com">
+<link rel="dns-prefetch" href="https://fonts.gstatic.com">
+<link rel="dns-prefetch" href="https://www.googletagmanager.com">
+<link rel="dns-prefetch" href="https://www.gravatar.com">
+<link rel="preconnect" href="https://@(options.ExternalLinks?.Cdn?.Host)">
+<link rel="preconnect" href="https://cdnjs.cloudflare.com">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com">
+<link rel="preconnect" href="https://www.googletagmanager.com">
+<link rel="preconnect" href="https://www.gravatar.com">
+<link rel="canonical" href="@canonical">
+<link rel="manifest" href="@Url.Content("~/manifest.webmanifest")">
+<link rel="sitemap" type="application/xml" href="@Url.Content("~/sitemap.xml")" asp-append-version="true">
+<link rel="shortcut icon" href="@request.CdnContent("favicon.ico", options)">
+<link rel="shortcut icon" sizes="16x16" href="@request.CdnContent("favicon-16x16.png", options)">
+<link rel="shortcut icon" sizes="32x32" href="@request.CdnContent("favicon-32x32.png", options)">
+<link rel="shortcut icon" sizes="96x96" href="@request.CdnContent("favicon-96x96.png", options)">
+<link rel="shortcut icon" sizes="152x152" href="@request.CdnContent("favicon-152x152.png", options)">
+<link rel="shortcut icon" sizes="192x192" href="@request.CdnContent("favicon-192x192.png", options)">
+<link rel="shortcut icon" sizes="196x196" href="@request.CdnContent("favicon-196x196.png", options)">
+<link rel="apple-touch-icon" href="@request.CdnContent("apple-touch-icon-180x180.png", options)">

--- a/src/LondonTravel.Site/Views/Shared/_Meta.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Meta.cshtml
@@ -4,113 +4,114 @@
 @inject IWebHostEnvironment Hosting
 @{
     bool renderAnalytics = string.Equals(Config.AzureEnvironment(), "production", StringComparison.OrdinalIgnoreCase);
+    var request = Context.Request;
 }
-    <meta charset="utf-8" />
-    <title>@Model!.Title</title>
-    <meta name="author" content="@Model.Author" />
-    <meta name="bitcoin" content="@Model.Bitcoin" />
-    <meta name="copyright" content="@SR.CopyrightText" />
-    <meta name="description" content="@Model.Description" />
-    <meta name="language" content="en" />
-    <meta name="keywords" content="@Model.Keywords" />
-    <meta name="referrer" content="no-referrer-when-downgrade" />
-    <meta name="robots" content="@Model.Robots" />
-    <meta name="theme-color" content="#ffffff" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta property="fb:app_id" content="@Model.FacebookApp" />
-    <meta property="fb:profile_id" content="@Model.FacebookProfile" />
-    <meta property="og:description" content="@Model.Description" />
-    @if (!string.IsNullOrEmpty(Model.ImageUri))
-    {
+<meta charset="utf-8" />
+<title>@Model!.Title</title>
+<meta name="author" content="@Model.Author" />
+<meta name="bitcoin" content="@Model.Bitcoin" />
+<meta name="copyright" content="@SR.CopyrightText" />
+<meta name="description" content="@Model.Description" />
+<meta name="language" content="en" />
+<meta name="keywords" content="@Model.Keywords" />
+<meta name="referrer" content="no-referrer-when-downgrade" />
+<meta name="robots" content="@Model.Robots" />
+<meta name="theme-color" content="#ffffff" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta property="fb:app_id" content="@Model.FacebookApp" />
+<meta property="fb:profile_id" content="@Model.FacebookProfile" />
+<meta property="og:description" content="@Model.Description" />
+@if (!string.IsNullOrEmpty(Model.ImageUri))
+{
     <meta property="og:image" content="@Model.ImageUri" />
     <meta name="twitter:image" content="@Model.ImageUri" />
     <meta name="twitter:image:alt" content="@Model.ImageAltText" />
-    }
-    else
-    {
-    <meta property="og:image" content="@Url.CdnContent("london-travel-216x216.png", Options)" />
-    <meta property="og:image:secure_url" content="@Url.CdnContent("london-travel-216x216.png", Options)" />
+}
+else
+{
+    <meta property="og:image" content="@request.CdnContent("london-travel-216x216.png", Options)" />
+    <meta property="og:image:secure_url" content="@request.CdnContent("london-travel-216x216.png", Options)" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="216" />
     <meta property="og:image:height" content="216" />
-    <meta name="twitter:image" content="@Url.CdnContent("london-travel-108x108.png", Options)" />
+    <meta name="twitter:image" content="@request.CdnContent("london-travel-108x108.png", Options)" />
     <meta name="twitter:image:alt" content="@Model.SiteName" />
-    }
-    <meta property="og:locale" content="en_GB" />
-    <meta property="og:site_name" content="@Model.SiteName" />
-    <meta property="og:title" content="@Model.Title" />
-    <meta property="og:type" content="@Model.SiteType" />
-    <meta property="og:url" content="@Model.CanonicalUri" />
-    <meta name="twitter:card" content="@Model.TwitterCard" />
-    <meta name="twitter:creator" content="@Model.TwitterHandle" />
-    <meta name="twitter:description" content="@Model.Description" />
-    <meta name="twitter:domain" content="@Model.HostName" />
-    <meta name="twitter:site" content="@Model.TwitterHandle" />
-    <meta name="twitter:title" content="@Model.Title" />
-    <meta name="twitter:url" content="@Model.CanonicalUri" />
-    <meta name="application-name" content="@Model.SiteName" />
-    <meta name="google-analytics" content="@(renderAnalytics ? Options.Analytics?.Google : string.Empty)" />
-    <meta name="google-site-verification" content="ji6SNsPQEbNQmF252sQgQFswh-b6cDnNOa3AHvgo4J0" />
-    <meta name="msapplication-config" content="@Url.Content("~/browserconfig.xml")" />
-    <meta name="msapplication-navbutton-color" content="#2b5797" />
-    <meta name="msapplication-starturl" content="/" />
-    <meta name="msapplication-TileColor" content="#2b5797" />
-    <meta name="msapplication-TileImage" content="@Url.CdnContent("mstile-144x144.png", Options)" />
-    <meta name="x-request-locale" content="@CultureInfo.CurrentUICulture.Name" />
-    <meta name="x-site-branch" content="@GitMetadata.Branch" />
-    <meta name="x-site-revision" content="@GitMetadata.Commit" />
-    @if (User?.Identity?.IsAuthenticated == true)
-    {
+}
+<meta property="og:locale" content="en_GB" />
+<meta property="og:site_name" content="@Model.SiteName" />
+<meta property="og:title" content="@Model.Title" />
+<meta property="og:type" content="@Model.SiteType" />
+<meta property="og:url" content="@Model.CanonicalUri" />
+<meta name="twitter:card" content="@Model.TwitterCard" />
+<meta name="twitter:creator" content="@Model.TwitterHandle" />
+<meta name="twitter:description" content="@Model.Description" />
+<meta name="twitter:domain" content="@Model.HostName" />
+<meta name="twitter:site" content="@Model.TwitterHandle" />
+<meta name="twitter:title" content="@Model.Title" />
+<meta name="twitter:url" content="@Model.CanonicalUri" />
+<meta name="application-name" content="@Model.SiteName" />
+<meta name="google-analytics" content="@(renderAnalytics ? Options.Analytics?.Google : string.Empty)" />
+<meta name="google-site-verification" content="ji6SNsPQEbNQmF252sQgQFswh-b6cDnNOa3AHvgo4J0" />
+<meta name="msapplication-config" content="@Url.Content("~/browserconfig.xml")" />
+<meta name="msapplication-navbutton-color" content="#2b5797" />
+<meta name="msapplication-starturl" content="/" />
+<meta name="msapplication-TileColor" content="#2b5797" />
+<meta name="msapplication-TileImage" content="@request.CdnContent("mstile-144x144.png", Options)" />
+<meta name="x-request-locale" content="@CultureInfo.CurrentUICulture.Name" />
+<meta name="x-site-branch" content="@GitMetadata.Branch" />
+<meta name="x-site-revision" content="@GitMetadata.Commit" />
+@if (User?.Identity?.IsAuthenticated == true)
+{
     <meta name="x-site-user-id" content="@User.GetUserId()" />
-    }
-    <script type="application/ld+json">
-    {
+}
+<script type="application/ld+json">
+{
+    "@@context": "http://schema.org",
+    "@@type": "WebSite",
+    "name": "@Model.SiteName",
+    "alternateName": "@Model.Description",
+    "author" : {
+        "@@type" : "Person",
+        "name" : "@Options.Metadata?.Author?.Name"
+    },
+    "description": "@Model.Description",
+    "image": "@Options.Metadata?.Image",
+    "url": "@Context.Request.Canonical("/")"
+}
+</script>
+<script type="application/ld+json">
+{
+    "@@context" : "http://schema.org",
+    "@@type" : "SoftwareApplication",
+    "name" : "@Model.SiteName",
+    "aggregateRating": {
         "@@context": "http://schema.org",
-        "@@type": "WebSite",
-        "name": "@Model.SiteName",
-        "alternateName": "@Model.Description",
-        "author" : {
-            "@@type" : "Person",
-            "name" : "@Options.Metadata?.Author?.Name"
-        },
-        "description": "@Model.Description",
-        "image": "@Options.Metadata?.Image",
-        "url": "@Context.Request.Canonical("/")"
-    }
-    </script>
-    <script type="application/ld+json">
-    {
-        "@@context" : "http://schema.org",
-        "@@type" : "SoftwareApplication",
-        "name" : "@Model.SiteName",
-        "aggregateRating": {
-            "@@context": "http://schema.org",
-            "@@type": "AggregateRating",
-            "bestRating": @Model.Reviews?.BestRating,
-            "worstRating": @Model.Reviews?.WorstRating,
-            "ratingValue": @Model.Reviews?.AverageRating,
-            "reviewCount": @Model.Reviews?.ReviewCount
-        },
-        "applicationCategory": "Travel & Transportation",
-        "applicationSubCategory": "Public Transportation",
-        "author" : {
-            "@@type" : "Person",
-            "name" : "@Options.Metadata?.Author?.Name"
-        },
-        "countriesSupported": "gb",
-        "dateCreated": "2017-02-04",
-        "description": "The London Travel Alexa skill allows you to ask Alexa for information about disruption on public transport in London.",
-        "installUrl": "@Options.ExternalLinks?.Skill",
-        "inLanguage": "en-GB",
-        "license": "https://github.com/martincostello/alexa-london-travel/blob/main/LICENSE",
-        "offers": {
-            "@@context": "http://schema.org",
-            "@@type": "Offer",
-            "price": "0.00",
-            "priceCurrency": "GBP"
-        },
-        "operatingSystem": "Amazon Echo",
-        "releaseNotes": "https://github.com/martincostello/alexa-london-travel/releases/latest",
-        "url": "https://github.com/martincostello/alexa-london-travel"
-    }
-    </script>
+        "@@type": "AggregateRating",
+        "bestRating": @Model.Reviews?.BestRating,
+        "worstRating": @Model.Reviews?.WorstRating,
+        "ratingValue": @Model.Reviews?.AverageRating,
+        "reviewCount": @Model.Reviews?.ReviewCount
+    },
+    "applicationCategory": "Travel & Transportation",
+    "applicationSubCategory": "Public Transportation",
+    "author" : {
+        "@@type" : "Person",
+        "name" : "@Options.Metadata?.Author?.Name"
+    },
+    "countriesSupported": "gb",
+    "dateCreated": "2017-02-04",
+    "description": "The London Travel Alexa skill allows you to ask Alexa for information about disruption on public transport in London.",
+    "installUrl": "@Options.ExternalLinks?.Skill",
+    "inLanguage": "en-GB",
+    "license": "https://github.com/martincostello/alexa-london-travel/blob/main/LICENSE",
+    "offers": {
+        "@@context": "http://schema.org",
+        "@@type": "Offer",
+        "price": "0.00",
+        "priceCurrency": "GBP"
+    },
+    "operatingSystem": "Amazon Echo",
+    "releaseNotes": "https://github.com/martincostello/alexa-london-travel/releases/latest",
+    "url": "https://github.com/martincostello/alexa-london-travel"
+}
+</script>

--- a/src/LondonTravel.Site/Views/Shared/_Navbar.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_Navbar.cshtml
@@ -1,11 +1,14 @@
+@{
+    var request = Context.Request;
+}
 <nav class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
     <div class="container">
         <a asp-page="@SiteRoutes.Home" class="navbar-brand" title="@SR.HomepageLinkAltText" data-ga-label="Homepage Navbar">
             <span>
                 @SR.BrandName
-                <lazyimg src="@Url.CdnContent("avatar.png", Options)" class="pb-1" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
+                <lazyimg src="@request.CdnContent("avatar.png", Options)" class="pb-1" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
                 <noscript>
-                    <img src="@Url.CdnContent("avatar.png", Options)" class="pb-1" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
+                    <img src="@request.CdnContent("avatar.png", Options)" class="pb-1" alt="@SR.BrandName" title="@SR.BrandName" aria-hidden="true" />
                 </noscript>
             </span>
         </a>

--- a/src/LondonTravel.Site/Views/Shared/_SignInPartial.cshtml
+++ b/src/LondonTravel.Site/Views/Shared/_SignInPartial.cshtml
@@ -1,7 +1,7 @@
 @inject Microsoft.AspNetCore.Identity.SignInManager<LondonTravelUser> SignInManager
 @{
     string displayName = User.GetDisplayName();
-    string avatarUrl = User.GetAvatarUrl(Url.CdnContent("avatar.png", Options));
+    string avatarUrl = User.GetAvatarUrl(Context.Request.CdnContent("avatar.png", Options));
 }
 @if (SignInManager.IsSignedIn(User))
 {


### PR DESCRIPTION
- Construct CDN URLs with strings to avoid `Uri` allocations.
- Remove redundant DNS preload domains.
