### PR TITLE
Set JsonNumberHandling.Strict

### DIFF
--- a/src/LondonTravel.Site/ApplicationJsonSerializerContext.cs
+++ b/src/LondonTravel.Site/ApplicationJsonSerializerContext.cs
@@ -15,5 +15,10 @@ namespace MartinCostello.LondonTravel.Site;
 [JsonSerializable(typeof(ICollection<StopPoint>))]
 [JsonSerializable(typeof(JsonObject))]
 [JsonSerializable(typeof(PreferencesResponse))]
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    NumberHandling = JsonNumberHandling.Strict,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    PropertyNameCaseInsensitive = false,
+    WriteIndented = true)]
 internal sealed partial class ApplicationJsonSerializerContext : JsonSerializerContext;

--- a/src/LondonTravel.Site/LondonTravelSiteBuilder.cs
+++ b/src/LondonTravel.Site/LondonTravelSiteBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.IO.Compression;
+using System.Text.Json.Serialization;
 using Azure.Identity;
 using Azure.Storage.Blobs;
 using MartinCostello.LondonTravel.Site.Extensions;
@@ -168,7 +169,8 @@ public static class LondonTravelSiteBuilder
 
         builder.Services.ConfigureHttpJsonOptions((options) =>
         {
-            options.SerializerOptions.DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull;
+            options.SerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+            options.SerializerOptions.NumberHandling = JsonNumberHandling.Strict;
             options.SerializerOptions.PropertyNameCaseInsensitive = false;
             options.SerializerOptions.WriteIndented = true;
             options.SerializerOptions.TypeInfoResolverChain.Add(ApplicationJsonSerializerContext.Default);


### PR DESCRIPTION
Set `JsonNumberHandling.Strict` for JSON serialization to avoid behaviour change with OpenAPI in .NET 10.
