### PR TITLE
Add job timeout

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
 


### PR DESCRIPTION
Timeout the Lighthouse job after 10 minutes to avoid hangs that keep the job running for up to 6 hours.
