### PR TITLE
Set deployment.environment.name

### DIFF
--- a/src/LondonTravel.Site/ApplicationTelemetry.cs
+++ b/src/LondonTravel.Site/ApplicationTelemetry.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
-using OpenTelemetry;
 using OpenTelemetry.Resources;
 using Pyroscope;
 
@@ -17,6 +16,7 @@ public static class ApplicationTelemetry
 
     public static ResourceBuilder ResourceBuilder { get; } = ResourceBuilder.CreateDefault()
         .AddService(ServiceName, ServiceNamespace, ServiceVersion)
+        .AddAttributes([new KeyValuePair<string, object>("deployment.environment.name", Environment.GetEnvironmentVariable("Azure__Environment") ?? string.Empty)])
         .AddAzureAppServiceDetector()
         .AddContainerDetector()
         .AddHostDetector()


### PR DESCRIPTION
Set `deployment.environment.name` as App Service no longer sets `WEBSITE_SLOT_NAME`.
