### PR TITLE
Use repository dispatch for annotations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
     needs: [ build ]
     uses: ./.github/workflows/deploy-app.yml
     permissions:
-      contents: read
+      contents: write
       id-token: write
       pull-requests: write
     secrets: inherit
@@ -274,7 +274,7 @@ jobs:
     needs: [ build, deploy-dev ]
     uses: ./.github/workflows/deploy-app.yml
     permissions:
-      contents: read
+      contents: write
       id-token: write
       pull-requests: write
     secrets: inherit

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -55,6 +55,7 @@ jobs:
       url: ${{ inputs.environment-url }}
 
     permissions:
+      contents: write
       id-token: write
       pull-requests: write
 
@@ -64,46 +65,29 @@ jobs:
     steps:
 
     - name: Create deployment annotation
-      id: annotate-deployment
-      if: ${{ vars.TELEMETRY_URL && vars.TELEMETRY_URL != '' }}
-      shell: pwsh
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       env:
         APPLICATION_NAME: ${{ inputs.application-name }}
         ENVIRONMENT_NAME: ${{ inputs.environment-name }}
-        TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_TOKEN }}
-        TELEMETRY_URL: ${{ vars.TELEMETRY_URL }}
-      run: |
-        $commitSha = ${env:GITHUB_SHA}.Substring(0, 7)
-        $commitUrl = "${env:GITHUB_SERVER_URL}/${env:GITHUB_REPOSITORY}/commit/${env:GITHUB_SHA}"
-        $workflowUrl = "${env:GITHUB_SERVER_URL}/${env:GITHUB_REPOSITORY}/actions/runs/${env:GITHUB_RUN_ID}"
-
-        $body = @{
-          tags = @(
-            "deployment",
-            "environment:${env:ENVIRONMENT_NAME}",
-            "service:${env:APPLICATION_NAME}"
-          );
-          text = "Deployed <a href='${workflowUrl}'>#${env:GITHUB_RUN_NUMBER}:${env:GITHUB_RUN_ATTEMPT}</a> with commit <a href='${commitUrl}'>${commitSha}</a>";
-          time = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds();
-        } | ConvertTo-Json
-
-        try {
-          $annotation = Invoke-RestMethod -Uri "${env:TELEMETRY_URL}/api/annotations" `
-            -Method Post `
-            -Headers @{
-              "Accept" = "application/json";
-              "Authorization" = "Bearer ${env:TELEMETRY_TOKEN}";
-              "Content-Type" = "application/json";
-            } `
-            -Body $body
-
-          $id = $annotation.id
-
-          Write-Output "Created deployment annotation ${id}"
-          "id=${id}" >> ${env:GITHUB_OUTPUT}
-        } catch {
-          Write-Output "::warning::Failed to create deployment annotation"
-        }
+      with:
+        script: |
+          const { repo, owner } = context.repo;
+          await github.rest.repos.createDispatchEvent({
+            owner,
+            repo,
+            event_type: 'deployment_started',
+            client_payload: {
+              application: process.env.APPLICATION_NAME,
+              environment: process.env.ENVIRONMENT_NAME,
+              repository: process.env.GITHUB_REPOSITORY,
+              runAttempt: process.env.GITHUB_RUN_ATTEMPT,
+              runId: process.env.GITHUB_RUN_ID,
+              runNumber: process.env.GITHUB_RUN_NUMBER,
+              serverUrl: process.env.GITHUB_SERVER_URL,
+              sha: process.env.GITHUB_SHA,
+              timestamp: Date.now(),
+            }
+          });
 
     - name: Post deployment starting comment
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -170,31 +154,22 @@ jobs:
         }
 
     - name: Update deployment annotation
-      if: ${{ !cancelled() && steps.annotate-deployment.outputs.id != '' }}
-      shell: pwsh
-      env:
-        ANNOTATION_ID: ${{ steps.annotate-deployment.outputs.id }}
-        TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_TOKEN }}
-        TELEMETRY_URL: ${{ vars.TELEMETRY_URL }}
-      run: |
-        $body = @{
-          timeEnd = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds();
-        } | ConvertTo-Json
-
-        try {
-          Invoke-RestMethod -Uri "${env:TELEMETRY_URL}/api/annotations/${env:ANNOTATION_ID}" `
-            -Method Patch `
-            -Headers @{
-              "Accept" = "application/json";
-              "Authorization" = "Bearer ${env:TELEMETRY_TOKEN}";
-              "Content-Type" = "application/json";
-            } `
-            -Body $body | Out-Null
-
-          Write-Output "Updated deployment annotation ${env:ANNOTATION_ID}"
-        } catch {
-          Write-Output "::warning::Failed to update deployment annotation ${env:ANNOTATION_ID}"
-        }
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      if: ${{ !cancelled() }}
+      with:
+        script: |
+          const { repo, owner } = context.repo;
+          await github.rest.repos.createDispatchEvent({
+            owner,
+            repo,
+            event_type: 'deployment_completed',
+            client_payload: {
+              repository: process.env.GITHUB_REPOSITORY,
+              runAttempt: process.env.GITHUB_RUN_ATTEMPT,
+              runNumber: process.env.GITHUB_RUN_NUMBER,
+              timestamp: Date.now(),
+            }
+          });
 
     - name: Post deployment finished comment
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,7 +143,7 @@ jobs:
     needs: [ setup ]
     uses: ./.github/workflows/deploy-app.yml
     permissions:
-      contents: read
+      contents: write
       id-token: write
       pull-requests: write
     secrets: inherit


### PR DESCRIPTION
Simplify deployment annotations by using `repository_dispatch` to delegate creation.
