### PR TITLE
Enable PKCE for GitHub OAuth

### DIFF
--- a/src/LondonTravel.Site/Identity/AuthenticationBuilderExtensions.cs
+++ b/src/LondonTravel.Site/Identity/AuthenticationBuilderExtensions.cs
@@ -75,7 +75,13 @@ public static partial class AuthenticationBuilderExtensions
         if (IsProviderEnabled(name, options))
         {
             builder.AddGitHub()
-                   .Configure<GitHubAuthenticationOptions>(name, (p, _) => p.Scope.Add("user:email"));
+                   .Configure<GitHubAuthenticationOptions>(
+                       name,
+                       (p, _) =>
+                       {
+                           p.Scope.Add("user:email");
+                           p.UsePkce = true;
+                       });
         }
 
         return builder;


### PR DESCRIPTION
Enable use of PKCE when signing in with GitHub OAuth.

See [_PKCE support for OAuth and GitHub App authentication_](https://github.blog/changelog/2025-07-14-pkce-support-for-oauth-and-github-app-authentication/).

