### PR TITLE
Fix constant condition

### DIFF
--- a/src/LondonTravel.Site/Controllers/AccountController.cs
+++ b/src/LondonTravel.Site/Controllers/AccountController.cs
@@ -22,7 +22,7 @@ public partial class AccountController(
 {
     private readonly bool _isEnabled =
         siteOptions?.Authentication?.IsEnabled == true &&
-        siteOptions.Authentication.ExternalProviders?.Any((p) => p.Value?.IsEnabled == true);
+        siteOptions.Authentication.ExternalProviders?.Any((p) => p.Value?.IsEnabled == true) == true;
 
     [AllowAnonymous]
     [HttpGet]

--- a/src/LondonTravel.Site/Controllers/AccountController.cs
+++ b/src/LondonTravel.Site/Controllers/AccountController.cs
@@ -22,7 +22,7 @@ public partial class AccountController(
 {
     private readonly bool _isEnabled =
         siteOptions?.Authentication?.IsEnabled == true &&
-        siteOptions.Authentication.ExternalProviders?.Any((p) => p.Value?.IsEnabled == true) == true;
+        siteOptions.Authentication.ExternalProviders?.Any((p) => p.Value?.IsEnabled == true);
 
     [AllowAnonymous]
     [HttpGet]

--- a/src/LondonTravel.Site/Controllers/AccountController.cs
+++ b/src/LondonTravel.Site/Controllers/AccountController.cs
@@ -22,7 +22,7 @@ public partial class AccountController(
 {
     private readonly bool _isEnabled =
         siteOptions?.Authentication?.IsEnabled == true &&
-        siteOptions?.Authentication.ExternalProviders?.Any((p) => p.Value?.IsEnabled == true) == true;
+        siteOptions.Authentication.ExternalProviders?.Any((p) => p.Value?.IsEnabled == true) == true;
 
     [AllowAnonymous]
     [HttpGet]


### PR DESCRIPTION
The options won't be null if the previous statement was true.

Fixes https://github.com/martincostello/alexa-london-travel-site/security/code-scanning/420.
