### PR TITLE
Remove rollForward

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,6 @@
   "sdk": {
     "version": "10.0.301",
     "allowPrerelease": false,
-    "rollForward": "latestMajor",
     "paths": [
       ".dotnet",
       "$host$"


### PR DESCRIPTION
Remove rollForward as it breaks `actions/setup-dotnet` if the desired version isn't installed on the runner.
